### PR TITLE
Don't throw error when converting identical currencies

### DIFF
--- a/src/Classes/ExchangeRate.php
+++ b/src/Classes/ExchangeRate.php
@@ -177,8 +177,9 @@ class ExchangeRate
      */
     public function convert(int $value, string $from, string $to, Carbon $date = null): float
     {
+        if ($from === $to) return $value;
+
         return (float) $this->exchangeRate($from, $to, $date) * $value;
-    }
 
     /**
      * Return an array of the converted values between

--- a/src/Classes/ExchangeRate.php
+++ b/src/Classes/ExchangeRate.php
@@ -180,6 +180,7 @@ class ExchangeRate
         if ($from === $to) return $value;
 
         return (float) $this->exchangeRate($from, $to, $date) * $value;
+    }
 
     /**
      * Return an array of the converted values between

--- a/src/Classes/ExchangeRate.php
+++ b/src/Classes/ExchangeRate.php
@@ -177,7 +177,9 @@ class ExchangeRate
      */
     public function convert(int $value, string $from, string $to, Carbon $date = null): float
     {
-        if ($from === $to) return $value;
+        if ($from === $to) {
+            return $value;
+        }
 
         return (float) $this->exchangeRate($from, $to, $date) * $value;
     }

--- a/tests/Unit/ConvertTest.php
+++ b/tests/Unit/ConvertTest.php
@@ -25,7 +25,7 @@ class ConvertTest extends TestCase
         $this->assertEquals('86.158', $rate);
     }
 
-     /** @test */
+    /** @test */
     public function convert_still_works_if_to_and_from_value_are_identical()
     {
         $exchangeRate = new ExchangeRate();

--- a/tests/Unit/ConvertTest.php
+++ b/tests/Unit/ConvertTest.php
@@ -26,12 +26,12 @@ class ConvertTest extends TestCase
     }
 
      /** @test */
-     public function convert_still_works_if_to_and_from_value_are_identical()
-     {
-         $exchangeRate = new ExchangeRate();
-         $rate = $exchangeRate->convert(100, 'EUR', 'EUR');
-         $this->assertEquals('100', $rate);
-     }
+    public function convert_still_works_if_to_and_from_value_are_identical()
+    {
+        $exchangeRate = new ExchangeRate();
+        $rate = $exchangeRate->convert(100, 'EUR', 'EUR');
+        $this->assertEquals('100', $rate);
+    }
 
     /** @test */
     public function converted_value_in_the_past_is_returned_if_date_parameter_passed_and_rate_is_not_cached()

--- a/tests/Unit/ConvertTest.php
+++ b/tests/Unit/ConvertTest.php
@@ -25,6 +25,14 @@ class ConvertTest extends TestCase
         $this->assertEquals('86.158', $rate);
     }
 
+     /** @test */
+     public function convert_still_works_if_to_and_from_value_are_identical()
+     {
+         $exchangeRate = new ExchangeRate();
+         $rate = $exchangeRate->convert(100, 'EUR', 'EUR');
+         $this->assertEquals('100', $rate);
+     }
+
     /** @test */
     public function converted_value_in_the_past_is_returned_if_date_parameter_passed_and_rate_is_not_cached()
     {


### PR DESCRIPTION
Before:

```
ExchangeRate::convert(100, 'EUR', 'EUR');

--

PHP Notice:  Undefined index: EUR in /Users/sputnik/bbg/reservation-apis/vendor/ashallendesign/laravel-exchange-rates/src/Classes/ExchangeRate.php on line 107
TypeError: Return value of AshAllenDesign/LaravelExchangeRates/Classes/ExchangeRate::exchangeRate() must be of the type string, null returned
```

After:

```
ExchangeRate::convert(100, 'EUR', 'EUR');

--

100
```