### PR TITLE
Building offline results for exchange rates between same currencies

### DIFF
--- a/src/Classes/ExchangeRate.php
+++ b/src/Classes/ExchangeRate.php
@@ -94,6 +94,10 @@ class ExchangeRate
             Validation::validateDate($date);
         }
 
+        if ($from === $to) {
+            return 1.0;
+        }
+
         $cacheKey = $this->cacheRepository->buildCacheKey($from, $to, $date ?? now());
 
         if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {

--- a/src/Classes/ExchangeRate.php
+++ b/src/Classes/ExchangeRate.php
@@ -235,7 +235,7 @@ class ExchangeRate
         Carbon $endDate,
         array $conversions = []
     ): array {
-        for ($resultDate = clone($date); $resultDate->lte($endDate); $resultDate->addDay()) {
+        for ($resultDate = clone $date; $resultDate->lte($endDate); $resultDate->addDay()) {
             if ($resultDate->isWeekday()) {
                 $conversions[$resultDate->format('Y-m-d')] = 1.0;
             }

--- a/src/Classes/ExchangeRate.php
+++ b/src/Classes/ExchangeRate.php
@@ -140,6 +140,16 @@ class ExchangeRate
         Validation::validateCurrencyCode($to);
         Validation::validateStartAndEndDates($date, $endDate);
 
+        if ($from === $to) {
+            for ($startDate = $date; $startDate->lte($endDate); $startDate->addDay()) {
+                if ($date->isWeekday()) {
+                    $conversions[$date->format('Y-m-d')] = 1.0;
+                }
+            }
+
+            return $conversions;
+        }
+
         $cacheKey = $this->cacheRepository->buildCacheKey($from, $to, $date, $endDate);
 
         if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {

--- a/src/Classes/ExchangeRate.php
+++ b/src/Classes/ExchangeRate.php
@@ -244,6 +244,15 @@ class ExchangeRate
         return $conversions;
     }
 
+    /**
+     * Determine whether if the cached result (if it
+     * exists) should be deleted. This will force
+     * a new exchange rate to be fetched from
+     * the API.
+     *
+     * @param  bool  $bustCache
+     * @return $this
+     */
     public function shouldBustCache(bool $bustCache = true): self
     {
         $this->shouldBustCache = $bustCache;
@@ -251,6 +260,15 @@ class ExchangeRate
         return $this;
     }
 
+    /**
+     * Attempt to fetch an item (more than likely an
+     * exchange rate) from the cache. If it exists,
+     * return it. If it has been specified, bust
+     * the cache.
+     *
+     * @param  string  $cacheKey
+     * @return mixed
+     */
     private function attemptToResolveFromCache(string $cacheKey)
     {
         if ($this->shouldBustCache) {

--- a/src/Classes/ExchangeRate.php
+++ b/src/Classes/ExchangeRate.php
@@ -225,19 +225,19 @@ class ExchangeRate
      * we can build the response ourselves to improve
      * the performance.
      *
-     * @param  Carbon  $date
+     * @param  Carbon  $startDate
      * @param  Carbon  $endDate
      * @param  array  $conversions
      * @return array
      */
     private function exchangeRateDateRangeResultWithSameCurrency(
-        Carbon $date,
+        Carbon $startDate,
         Carbon $endDate,
         array $conversions = []
     ): array {
-        for ($resultDate = clone $date; $resultDate->lte($endDate); $resultDate->addDay()) {
-            if ($resultDate->isWeekday()) {
-                $conversions[$resultDate->format('Y-m-d')] = 1.0;
+        for ($date = clone $startDate; $date->lte($endDate); $date->addDay()) {
+            if ($date->isWeekday()) {
+                $conversions[$date->format('Y-m-d')] = 1.0;
             }
         }
 

--- a/src/Classes/ExchangeRate.php
+++ b/src/Classes/ExchangeRate.php
@@ -141,13 +141,7 @@ class ExchangeRate
         Validation::validateStartAndEndDates($date, $endDate);
 
         if ($from === $to) {
-            for ($startDate = $date; $startDate->lte($endDate); $startDate->addDay()) {
-                if ($date->isWeekday()) {
-                    $conversions[$date->format('Y-m-d')] = 1.0;
-                }
-            }
-
-            return $conversions;
+            return $this->exchangeRateDateRangeResultWithSameCurrency($date, $endDate, $conversions);
         }
 
         $cacheKey = $this->cacheRepository->buildCacheKey($from, $to, $date, $endDate);
@@ -221,6 +215,31 @@ class ExchangeRate
         }
 
         ksort($conversions);
+
+        return $conversions;
+    }
+
+    /**
+     * If the 'from' and 'to' currencies are the same, we
+     * don't need to make a request to the API. Instead,
+     * we can build the response ourselves to improve
+     * the performance.
+     *
+     * @param  Carbon  $date
+     * @param  Carbon  $endDate
+     * @param  array  $conversions
+     * @return array
+     */
+    private function exchangeRateDateRangeResultWithSameCurrency(
+        Carbon $date,
+        Carbon $endDate,
+        array $conversions = []
+    ): array {
+        for ($startDate = $date; $startDate->lte($endDate); $startDate->addDay()) {
+            if ($date->isWeekday()) {
+                $conversions[$date->format('Y-m-d')] = 1.0;
+            }
+        }
 
         return $conversions;
     }

--- a/tests/Unit/ConvertBetweenDateRangeTest.php
+++ b/tests/Unit/ConvertBetweenDateRangeTest.php
@@ -6,6 +6,7 @@ use AshAllenDesign\LaravelExchangeRates\Classes\ExchangeRate;
 use AshAllenDesign\LaravelExchangeRates\Classes\RequestBuilder;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
 
@@ -137,6 +138,27 @@ class ConvertBetweenDateRangeTest extends TestCase
         ];
         $this->assertEquals($cachedExchangeRates,
             Cache::get('laravel_xr_GBP_EUR_'.$fromDate->format('Y-m-d').'_'.$toDate->format('Y-m-d')));
+    }
+
+    /** @test */
+    public function request_is_not_made_if_the_currencies_are_the_same()
+    {
+        $fromDate = Carbon::createFromDate(2019, 11, 4);
+        $toDate = Carbon::createFromDate(2019, 11, 10);
+
+        $requestBuilderMock = Mockery::mock(RequestBuilder::class)->makePartial();
+        $requestBuilderMock->expects('makeRequest')->withAnyArgs()->never();
+
+        $exchangeRate = new ExchangeRate($requestBuilderMock);
+        $currencies = $exchangeRate->convertBetweenDateRange(100, 'EUR', 'EUR', $fromDate, $toDate);
+
+        $this->assertEquals([
+            '2019-11-08' => 100.0,
+            '2019-11-06' => 100.0,
+            '2019-11-07' => 100.0,
+            '2019-11-05' => 100.0,
+            '2019-11-04' => 100.0,
+        ], $currencies);
     }
 
     /** @test */

--- a/tests/Unit/ConvertBetweenDateRangeTest.php
+++ b/tests/Unit/ConvertBetweenDateRangeTest.php
@@ -159,6 +159,16 @@ class ConvertBetweenDateRangeTest extends TestCase
             '2019-11-05' => 100.0,
             '2019-11-04' => 100.0,
         ], $currencies);
+
+        $cachedExchangeRates = [
+            '2019-11-08' => 1.0,
+            '2019-11-06' => 1.0,
+            '2019-11-07' => 1.0,
+            '2019-11-05' => 1.0,
+            '2019-11-04' => 1.0,
+        ];
+        $this->assertEquals($cachedExchangeRates,
+            Cache::get('laravel_xr_EUR_EUR_'.$fromDate->format('Y-m-d').'_'.$toDate->format('Y-m-d')));
     }
 
     /** @test */

--- a/tests/Unit/ConvertTest.php
+++ b/tests/Unit/ConvertTest.php
@@ -78,6 +78,17 @@ class ConvertTest extends TestCase
     }
 
     /** @test */
+    public function request_is_not_made_if_the_currencies_are_the_same()
+    {
+        $requestBuilderMock = Mockery::mock(RequestBuilder::class);
+        $requestBuilderMock->expects('makeRequest')->withAnyArgs()->never();
+
+        $exchangeRate = new ExchangeRate($requestBuilderMock);
+        $rate = $exchangeRate->convert(100, 'EUR', 'EUR');
+        $this->assertEquals('100', $rate);
+    }
+
+    /** @test */
     public function exception_is_thrown_if_the_date_parameter_passed_is_in_the_future()
     {
         $this->expectException(InvalidDateException::class);

--- a/tests/Unit/ExchangeRateBetweenDateRangeTest.php
+++ b/tests/Unit/ExchangeRateBetweenDateRangeTest.php
@@ -6,6 +6,7 @@ use AshAllenDesign\LaravelExchangeRates\Classes\ExchangeRate;
 use AshAllenDesign\LaravelExchangeRates\Classes\RequestBuilder;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
 
@@ -118,6 +119,29 @@ class ExchangeRateBetweenDateRangeTest extends TestCase
         $this->assertEquals($expectedArray, $currencies);
         $this->assertEquals($expectedArray,
             Cache::get('laravel_xr_GBP_EUR_'.$fromDate->format('Y-m-d').'_'.$toDate->format('Y-m-d')));
+    }
+
+    /** @test */
+    public function request_is_not_made_if_the_currencies_are_the_same()
+    {
+        $fromDate = Carbon::createFromDate(2019, 11, 4);
+        $toDate = Carbon::createFromDate(2019, 11, 10);
+
+        $requestBuilderMock = Mockery::mock(RequestBuilder::class)->makePartial();
+        $requestBuilderMock->expects('makeRequest')->withAnyArgs()->never();
+
+        $exchangeRate = new ExchangeRate($requestBuilderMock);
+        $currencies = $exchangeRate->exchangeRateBetweenDateRange('EUR', 'EUR', $fromDate, $toDate);
+
+        $expectedArray = [
+            '2019-11-08' => 1.0,
+            '2019-11-06' => 1.0,
+            '2019-11-07' => 1.0,
+            '2019-11-05' => 1.0,
+            '2019-11-04' => 1.0,
+        ];
+
+        $this->assertEquals($expectedArray, $currencies);
     }
 
     /** @test */

--- a/tests/Unit/ExchangeRateBetweenDateRangeTest.php
+++ b/tests/Unit/ExchangeRateBetweenDateRangeTest.php
@@ -142,6 +142,9 @@ class ExchangeRateBetweenDateRangeTest extends TestCase
         ];
 
         $this->assertEquals($expectedArray, $currencies);
+
+        $this->assertEquals($expectedArray,
+            Cache::get('laravel_xr_EUR_EUR_'.$fromDate->format('Y-m-d').'_'.$toDate->format('Y-m-d')));
     }
 
     /** @test */

--- a/tests/Unit/ExchangeRateTest.php
+++ b/tests/Unit/ExchangeRateTest.php
@@ -78,6 +78,17 @@ class ExchangeRateTest extends TestCase
     }
 
     /** @test */
+    public function request_is_not_made_if_the_currencies_are_the_same()
+    {
+        $requestBuilderMock = Mockery::mock(RequestBuilder::class);
+        $requestBuilderMock->expects('makeRequest')->withAnyArgs()->never();
+
+        $exchangeRate = new ExchangeRate($requestBuilderMock);
+        $rate = $exchangeRate->exchangeRate('EUR', 'EUR');
+        $this->assertEquals('1', $rate);
+    }
+
+    /** @test */
     public function exception_is_thrown_if_the_date_parameter_passed_is_in_the_future()
     {
         $this->expectException(InvalidDateException::class);


### PR DESCRIPTION
This PR prevents any requests from being made to the API if the exchange rate currencies are the same as each other.