### PR TITLE
Optional caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
     - [Facade](#facade)
     - [Examples](#examples)
     - [Caching](#caching)
+        - [Busting Cached Exchange Rates](#busting-cached-exchange-rates)
+        - [Preventing Exchange Rates from Being Cached](#preventing-exchange-rates-from-being-cached)
     - [Supported Currencies](#supported-currencies)
 - [Testing](#testing)
 - [Security](#security)
@@ -62,7 +64,6 @@ $exchangeRates->currencies();
 
 #### Exchange Rate
 ```php
-<?php
 $exchangeRates = new ExchangeRate();
 $exchangeRates->exchangeRate('GBP', 'EUR');
 ```
@@ -137,6 +138,7 @@ This example shows how to convert 100 pence (£1) from Great British Pounds to E
 ```
 
 ### Caching
+#### Busting Cached Exchange Rates
 By default, the responses all of the requests to the [exchangeratesapi.io](http://exchangeratesapi.io) API are cached.
 This allows for significant performance improvements and reduced bandwidth from your server. 
 
@@ -156,6 +158,27 @@ method can be used. The example below shows how to ignore the cached value (if o
         {
             $exchangeRates = new ExchangeRate();
             return $exchangeRates->shouldBustCache()->convert(100, 'GBP', 'EUR', Carbon::now());
+        }
+    }
+```
+
+#### Preventing Exchange Rates from Being Cached
+It is also possible to prevent the exchange rates from being cached at all. To do this, you can use the ``` ->shouldCache(false) ```
+method. The example below shows how to get an exchange rate and not cache it:
+
+```php
+<?php
+    
+    namespace App\Http\Controllers;
+    
+    use AshAllenDesign\LaravelExchangeRates\Classes\ExchangeRate;
+    
+    class TestController extends Controller
+    {
+        public function index()
+        {
+            $exchangeRates = new ExchangeRate();
+            return $exchangeRates->shouldCache(false)->convert(100, 'GBP', 'EUR', Carbon::now());
         }
     }
 ```

--- a/src/Classes/ExchangeRate.php
+++ b/src/Classes/ExchangeRate.php
@@ -228,7 +228,7 @@ class ExchangeRate
         array $conversions = []
     ): array {
         foreach ($this->exchangeRateBetweenDateRange($from, $to, $date, $endDate) as $date => $exchangeRate) {
-            $conversions[$date] = (float)$exchangeRate * $value;
+            $conversions[$date] = (float) $exchangeRate * $value;
         }
 
         ksort($conversions);

--- a/src/Classes/ExchangeRate.php
+++ b/src/Classes/ExchangeRate.php
@@ -7,7 +7,6 @@ use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use Carbon\Carbon;
 use Exception;
 use GuzzleHttp\Client;
-use Illuminate\Contracts\Container\BindingResolutionException;
 
 class ExchangeRate
 {
@@ -20,11 +19,24 @@ class ExchangeRate
     private $requestBuilder;
 
     /**
+     * The repository used for accessing the cache.
+     *
      * @var CacheRepository
      */
     private $cacheRepository;
 
     /**
+     * Whether of not the exchange rate should be cached
+     * after being fetched from the API.
+     *
+     * @var bool
+     */
+    private $shouldCache = true;
+
+    /**
+     * Whether or not the cache should be busted and a new
+     * value should be fetched from the API.
+     *
      * @var bool
      */
     private $shouldBustCache = false;
@@ -34,7 +46,6 @@ class ExchangeRate
      *
      * @param  RequestBuilder|null  $requestBuilder
      * @param  CacheRepository|null  $cacheRepository
-     * @throws BindingResolutionException
      */
     public function __construct(RequestBuilder $requestBuilder = null, CacheRepository $cacheRepository = null)
     {
@@ -66,7 +77,9 @@ class ExchangeRate
             $currencies[] = $currency;
         }
 
-        $this->cacheRepository->storeInCache($cacheKey, $currencies);
+        if ($this->shouldCache) {
+            $this->cacheRepository->storeInCache($cacheKey, $currencies);
+        }
 
         return $currencies;
     }
@@ -111,7 +124,9 @@ class ExchangeRate
             $exchangeRate = $this->requestBuilder->makeRequest('/latest', ['base' => $from])['rates'][$to];
         }
 
-        $this->cacheRepository->storeInCache($cacheKey, $exchangeRate);
+        if ($this->shouldCache) {
+            $this->cacheRepository->storeInCache($cacheKey, $exchangeRate);
+        }
 
         return $exchangeRate;
     }
@@ -163,7 +178,9 @@ class ExchangeRate
             ksort($conversions);
         }
 
-        $this->cacheRepository->storeInCache($cacheKey, $conversions);
+        if ($this->shouldCache) {
+            $this->cacheRepository->storeInCache($cacheKey, $conversions);
+        }
 
         return $conversions;
     }
@@ -211,7 +228,7 @@ class ExchangeRate
         array $conversions = []
     ): array {
         foreach ($this->exchangeRateBetweenDateRange($from, $to, $date, $endDate) as $date => $exchangeRate) {
-            $conversions[$date] = (float) $exchangeRate * $value;
+            $conversions[$date] = (float)$exchangeRate * $value;
         }
 
         ksort($conversions);
@@ -242,6 +259,20 @@ class ExchangeRate
         }
 
         return $conversions;
+    }
+
+    /**
+     * Determine whether if the exchange rate should be
+     * cached after it is fetched from the API.
+     *
+     * @param  bool  $shouldCache
+     * @return $this
+     */
+    public function shouldCache(bool $shouldCache = true): self
+    {
+        $this->shouldCache = $shouldCache;
+
+        return $this;
     }
 
     /**

--- a/tests/Unit/CurrenciesTest.php
+++ b/tests/Unit/CurrenciesTest.php
@@ -22,6 +22,8 @@ class CurrenciesTest extends TestCase
         $currencies = $exchangeRate->currencies();
 
         $this->assertEquals($this->expectedResponse(), $currencies);
+
+        $this->assertNotNull(Cache::get('laravel_xr_currencies'));
     }
 
     /** @test */
@@ -53,6 +55,23 @@ class CurrenciesTest extends TestCase
         $currencies = $exchangeRate->shouldBustCache()->currencies();
 
         $this->assertEquals($this->expectedResponse(), $currencies);
+    }
+
+    /** @test */
+    public function currencies_are_not_cached_if_the_shouldCache_option_is_false()
+    {
+        $requestBuilderMock = Mockery::mock(RequestBuilder::class)->makePartial();
+        $requestBuilderMock->expects('makeRequest')
+            ->withArgs(['/latest', []])
+            ->once()
+            ->andReturn($this->mockResponse());
+
+        $exchangeRate = new ExchangeRate($requestBuilderMock);
+        $currencies = $exchangeRate->shouldCache(false)->currencies();
+
+        $this->assertEquals($this->expectedResponse(), $currencies);
+
+        $this->assertNull(Cache::get('laravel_xr_currencies'));
     }
 
     private function mockResponse()

--- a/tests/Unit/ExchangeRateTest.php
+++ b/tests/Unit/ExchangeRateTest.php
@@ -78,6 +78,21 @@ class ExchangeRateTest extends TestCase
     }
 
     /** @test */
+    public function exchange_rate_is_not_cached_if_the_shouldCache_option_is_false()
+    {
+        $requestBuilderMock = Mockery::mock(RequestBuilder::class);
+        $requestBuilderMock->expects('makeRequest')
+            ->withArgs(['/latest', ['base' => 'EUR']])
+            ->once()
+            ->andReturn($this->mockResponseForCurrentDate());
+
+        $exchangeRate = new ExchangeRate($requestBuilderMock);
+        $rate = $exchangeRate->shouldCache(false)->exchangeRate('EUR', 'GBP');
+        $this->assertEquals('0.86158', $rate);
+        $this->assertNull(Cache::get('laravel_xr_EUR_GBP_'.now()->format('Y-m-d')));
+    }
+
+    /** @test */
     public function request_is_not_made_if_the_currencies_are_the_same()
     {
         $requestBuilderMock = Mockery::mock(RequestBuilder::class);


### PR DESCRIPTION
This PR adds a new method named ``` ->shouldCache() ``` that can be used to determine whether if the exchange rates should be cached when they're fetched from the API.