### PR TITLE
Date validation

### DIFF
--- a/src/Classes/Validation.php
+++ b/src/Classes/Validation.php
@@ -11,7 +11,7 @@ class Validation
     /**
      * A Carbon object for the earliest possible date that
      * an exchange rate can be fetched for. The date is:
-     * 4th January 2020
+     * 4th January 2020.
      *
      * @var Carbon|null
      */

--- a/src/Classes/Validation.php
+++ b/src/Classes/Validation.php
@@ -9,6 +9,15 @@ use Carbon\Carbon;
 class Validation
 {
     /**
+     * A Carbon object for the earliest possible date that
+     * an exchange rate can be fetched for. The date is:
+     * 4th January 2020
+     *
+     * @var Carbon|null
+     */
+    private static $earliestPossibleDate;
+
+    /**
      * Validate that the currency is supported by the
      * Exchange Rates API.
      *
@@ -57,6 +66,14 @@ class Validation
     {
         if (! $date->isPast()) {
             throw new InvalidDateException('The date must be in the past.');
+        }
+
+        if (! self::$earliestPossibleDate) {
+            self::$earliestPossibleDate = Carbon::createFromDate(1999, 1, 3);
+        }
+
+        if ($date->isBefore(static::$earliestPossibleDate)) {
+            throw new InvalidDateException('The date cannot be before 4th January 1999.');
         }
     }
 }

--- a/src/Classes/Validation.php
+++ b/src/Classes/Validation.php
@@ -69,7 +69,7 @@ class Validation
         }
 
         if (! self::$earliestPossibleDate) {
-            self::$earliestPossibleDate = Carbon::createFromDate(1999, 1, 3);
+            self::$earliestPossibleDate = Carbon::createFromDate(1999, 1, 4)->startOfDay();
         }
 
         if ($date->isBefore(static::$earliestPossibleDate)) {

--- a/tests/Unit/ExchangeRateTest.php
+++ b/tests/Unit/ExchangeRateTest.php
@@ -6,6 +6,7 @@ use AshAllenDesign\LaravelExchangeRates\Classes\ExchangeRate;
 use AshAllenDesign\LaravelExchangeRates\Classes\RequestBuilder;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
 
@@ -131,6 +132,16 @@ class ExchangeRateTest extends TestCase
 
         $exchangeRate = new ExchangeRate();
         $exchangeRate->exchangeRate('GBP', 'INVALID', now()->subMinute());
+    }
+
+    /** @test */
+    public function exception_is_thrown_if_the_date_is_before_the_earliest_possible_date()
+    {
+        $this->expectException(InvalidDateException::class);
+        $this->expectExceptionMessage('The date cannot be before 4th January 1999.');
+
+        $exchangeRate = new ExchangeRate();
+        $exchangeRate->exchangeRate('GBP', 'USD', Carbon::createFromDate(1999, 1, 3));
     }
 
     private function mockResponseForCurrentDate()


### PR DESCRIPTION
This PR fixes a bug that allowed a date before 4th January 1999 to be passed as a method parameter. The Exchange Rates API only provides exchange rates from this day onwards, so passing a date before the 4th January 1999 caused the API to return a ``` HTTP 400 ``` error.

A check is now made when validating the dates to ensure that they're after this earliest possible date. If it's not, an ``` InvalidDateException ``` is thrown.