### PR TITLE
Dropped support for Laravel 5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,6 @@ cache:
 matrix:
   fast_finish: true
   include:
-    #     Laravel 5.8.*
-    #       --> PHP 7.2
-    - php: 7.2
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.2
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
-    #       --> PHP 7.3
-    - php: 7.3
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.3
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
-    #       --> PHP 7.4
-    - php: 7.4
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
     #     Laravel 6.*
     #       --> PHP 7.2
     - php: 7.2

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ composer require ashallendesign/laravel-exchange-rates
 The package has been developed and tested to work with the following minimum requirements:
 
 - PHP 7.2
-- Laravel 5.8
+- Laravel 6
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "php": "^7.2",
     "nesbot/carbon": "~2.0",
     "guzzlehttp/guzzle": "^6.3",
-    "illuminate/container": "^5.8|^6.0|^7.0",
-    "illuminate/cache": "^5.8|^6.0|^7.0",
+    "illuminate/container": "^6.0|^7.0",
+    "illuminate/cache": "^6.0|^7.0",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
This PR drops support for Laravel 5.8 and makes Laravel 6 the minimum required version.