### PR TITLE
Laravel 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,9 @@ matrix:
 
 before_install:
   - travis_retry composer self-update
-  - travis_retry composer require --no-update --no-interaction "orchestra/testbench:${TESTBENCH}"
 
 install:
-  - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction --no-suggest
+  - travis_retry composer update --prefer-dist --no-interaction --no-suggest
   - travis_retry composer du -o
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,33 +8,26 @@ matrix:
   fast_finish: true
   include:
     #     Laravel 6.*
-    #       --> PHP 7.2
     - php: 7.2
-      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.2
-      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
-    #       --> PHP 7.3
+      env: LARAVEL='6.*'
     - php: 7.3
-      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.3
-      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
-    #       --> PHP 7.4
+      env: LARAVEL='6.*'
     - php: 7.4
-      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
+      env: LARAVEL='6.*'
     #     Laravel 7.*
-    #       --> PHP 7.2
     - php: 7.2
-      env: LARAVEL='7.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.2
-      env: LARAVEL='7.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
-    #       --> PHP 7.3
+      env: LARAVEL='7.*'
     - php: 7.3
-      env: LARAVEL='7.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.3
-      env: LARAVEL='7.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
-    #       --> PHP 7.4
+      env: LARAVEL='7.*'
     - php: 7.4
-      env: LARAVEL='7.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
+      env: LARAVEL='7.*'
+    #     Laravel 8.*
+    - php: 7.2
+      env: LARAVEL='8.*'
+    - php: 7.3
+      env: LARAVEL='8.*'
+    - php: 7.4
+      env: LARAVEL='8.*'
 
 before_install:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
   "require": {
     "php": "^7.2",
     "nesbot/carbon": "~2.0",
-    "guzzlehttp/guzzle": "^6.3",
-    "illuminate/container": "^6.0|^7.0",
-    "illuminate/cache": "^6.0|^7.0",
+    "guzzlehttp/guzzle": "^6.3|^7.0",
+    "illuminate/container": "^6.0|^7.0|^8.0",
+    "illuminate/cache": "^6.0|^7.0|^8.0",
     "ext-json": "*"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",
-    "orchestra/testbench": "^3.8 || ^4.0",
+    "orchestra/testbench": "^5.0|^6.0",
     "phpunit/phpunit": "^8.2"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require-dev": {
     "mockery/mockery": "^1.0",
-    "orchestra/testbench": "^5.0|^6.0",
+    "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",
     "phpunit/phpunit": "^8.2"
   },
   "autoload": {


### PR DESCRIPTION
This PR adds support for using the following new package versions:

- Laravel 8
- Guzzle 7
- Orchestra testbench 5 and 6