### PR TITLE
Changed InvalidCurrencyException messages

### DIFF
--- a/src/Classes/Validation.php
+++ b/src/Classes/Validation.php
@@ -31,7 +31,7 @@ class Validation
         $currencies = new Currency();
 
         if (! $currencies->isAllowableCurrency($currencyCode)) {
-            throw new InvalidCurrencyException($currencyCode.' is not a valid country code.');
+            throw new InvalidCurrencyException($currencyCode.' is not a valid currency code.');
         }
     }
 
@@ -48,7 +48,7 @@ class Validation
 
         foreach ($currencyCodes as $currencyCode) {
             if (! $currencies->isAllowableCurrency($currencyCode)) {
-                throw new InvalidCurrencyException($currencyCode.' is not a valid country code.');
+                throw new InvalidCurrencyException($currencyCode.' is not a valid currency code.');
             }
         }
     }

--- a/tests/Unit/ConvertBetweenDateRangeTest.php
+++ b/tests/Unit/ConvertBetweenDateRangeTest.php
@@ -250,7 +250,7 @@ class ConvertBetweenDateRangeTest extends TestCase
     public function exception_is_thrown_if_the_from_parameter_is_invalid()
     {
         $this->expectException(InvalidCurrencyException::class);
-        $this->expectExceptionMessage('INVALID is not a valid country code.');
+        $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
         $exchangeRate = new ExchangeRate();
         $exchangeRate->convertBetweenDateRange(100, 'INVALID', 'GBP', now()->subWeek(), now()->subDay());
@@ -260,7 +260,7 @@ class ConvertBetweenDateRangeTest extends TestCase
     public function exception_is_thrown_if_the_to_parameter_is_invalid()
     {
         $this->expectException(InvalidCurrencyException::class);
-        $this->expectExceptionMessage('INVALID is not a valid country code.');
+        $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
         $exchangeRate = new ExchangeRate();
         $exchangeRate->convertBetweenDateRange(100, 'GBP', 'INVALID', now()->subWeek(), now()->subDay());

--- a/tests/Unit/ConvertTest.php
+++ b/tests/Unit/ConvertTest.php
@@ -123,7 +123,7 @@ class ConvertTest extends TestCase
     public function exception_is_thrown_if_the_from_parameter_is_invalid()
     {
         $this->expectException(InvalidCurrencyException::class);
-        $this->expectExceptionMessage('INVALID is not a valid country code.');
+        $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
         $exchangeRate = new ExchangeRate();
         $exchangeRate->convert(100, 'INVALID', 'GBP', now()->subMinute());
@@ -133,7 +133,7 @@ class ConvertTest extends TestCase
     public function exception_is_thrown_if_the_to_parameter_is_invalid()
     {
         $this->expectException(InvalidCurrencyException::class);
-        $this->expectExceptionMessage('INVALID is not a valid country code.');
+        $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
         $exchangeRate = new ExchangeRate();
         $exchangeRate->convert(100, 'GBP', 'INVALID', now()->subMinute());

--- a/tests/Unit/ExchangeRateBetweenDateRangeTest.php
+++ b/tests/Unit/ExchangeRateBetweenDateRangeTest.php
@@ -254,7 +254,7 @@ class ExchangeRateBetweenDateRangeTest extends TestCase
     public function exception_is_thrown_if_the_from_parameter_is_invalid()
     {
         $this->expectException(InvalidCurrencyException::class);
-        $this->expectExceptionMessage('INVALID is not a valid country code.');
+        $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
         $exchangeRate = new ExchangeRate();
         $exchangeRate->exchangeRateBetweenDateRange('INVALID', 'GBP', now()->subWeek(), now()->subDay());
@@ -264,7 +264,7 @@ class ExchangeRateBetweenDateRangeTest extends TestCase
     public function exception_is_thrown_if_the_to_parameter_is_invalid()
     {
         $this->expectException(InvalidCurrencyException::class);
-        $this->expectExceptionMessage('INVALID is not a valid country code.');
+        $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
         $exchangeRate = new ExchangeRate();
         $exchangeRate->exchangeRateBetweenDateRange('GBP', 'INVALID', now()->subWeek(), now()->subDay());
@@ -274,7 +274,7 @@ class ExchangeRateBetweenDateRangeTest extends TestCase
     public function exception_is_thrown_if_one_of_the_to_parameter_currencies_are_invalid()
     {
         $this->expectException(InvalidCurrencyException::class);
-        $this->expectExceptionMessage('INVALID is not a valid country code.');
+        $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
         $exchangeRate = new ExchangeRate();
         $exchangeRate->exchangeRateBetweenDateRange('GBP', ['USD', 'INVALID'], now()->subWeek(), now()->subDay());

--- a/tests/Unit/ExchangeRateTest.php
+++ b/tests/Unit/ExchangeRateTest.php
@@ -181,7 +181,7 @@ class ExchangeRateTest extends TestCase
     public function exception_is_thrown_if_the_from_parameter_is_invalid()
     {
         $this->expectException(InvalidCurrencyException::class);
-        $this->expectExceptionMessage('INVALID is not a valid country code.');
+        $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
         $exchangeRate = new ExchangeRate();
         $exchangeRate->exchangeRate('INVALID', 'GBP', now()->subMinute());
@@ -191,7 +191,7 @@ class ExchangeRateTest extends TestCase
     public function exception_is_thrown_if_the_to_parameter_is_invalid()
     {
         $this->expectException(InvalidCurrencyException::class);
-        $this->expectExceptionMessage('INVALID is not a valid country code.');
+        $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
         $exchangeRate = new ExchangeRate();
         $exchangeRate->exchangeRate('GBP', 'INVALID', now()->subMinute());
@@ -211,7 +211,7 @@ class ExchangeRateTest extends TestCase
     public function exception_is_thrown_if_the_to_parameter_array_is_invalid()
     {
         $this->expectException(InvalidCurrencyException::class);
-        $this->expectExceptionMessage('INVALID is not a valid country code.');
+        $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
         $exchangeRate = new ExchangeRate();
         $exchangeRate->exchangeRate('GBP', ['INVALID'], now()->subMinute());


### PR DESCRIPTION
Changed the message when throwing `InvalidCurrencyException` from the Validation class' `validateCurrencyCode` and `validateCurrencyCodes` methods to better reflect the reason an exception was thrown. The current message may imply that country codes (ex. US, UK) were meant to be supplied, instead of currency codes (USD, GBP)