### PR TITLE
Allow configurable API key and base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 - [Overview](#overview)
 - [Installation](#installation)
+- [Configuration](#configuration)
 - [Usage](#usage)
     - [Methods](#methods)
         - [Available Currencies](#available-currencies)
@@ -61,6 +62,29 @@ The package has been developed and tested to work with the following minimum req
 
 - PHP 7.2
 - Laravel 6
+
+## Configuration
+
+In `config/services.php` file add:
+
+``` php
+'exchange_rates' => [
+    'api_key' => env('EXCHANGE_RATES_IO_API_KEY'),
+    'base_url' => env('EXCHANGE_RATES_IO_BASE_URL', 'http://api.exchangeratesapi.io'),
+],
+```
+
+Add the necessary configuration keys in your `.env`:
+
+``` dotenv
+EXCHANGE_RATES_IO_API_KEY=
+EXCHANGE_RATES_IO_BASE_URL=http://api.exchangeratesapi.io
+```
+
+As of 2021-04-01 seems like that free accounts are allowed to use only the HTTP protocol,
+while the paid ones can use HTTPS.
+
+It also seems that free accounts are limited to use a restricted set of currencies.
 
 ## Usage
 

--- a/src/Classes/RequestBuilder.php
+++ b/src/Classes/RequestBuilder.php
@@ -11,7 +11,14 @@ class RequestBuilder
      *
      * @var string
      */
-    private $baseUrl = 'https://api.exchangeratesapi.io';
+    private $baseUrl;
+
+    /**
+     * The API KEY for the Exchange Rates API.
+     *
+     * @var string
+     */
+    private $apiKey;
 
     /**
      * @var Client
@@ -26,6 +33,8 @@ class RequestBuilder
     public function __construct(Client $client = null)
     {
         $this->client = $client ?? new Client();
+        $this->baseUrl = config('services.exchange_rates.base_url');
+        $this->apiKey = config('services.exchange_rates.api_key');
     }
 
     /**
@@ -38,7 +47,7 @@ class RequestBuilder
      */
     public function makeRequest(string $path, array $queryParams = [])
     {
-        $url = $this->baseUrl.$path.'?';
+        $url = $this->baseUrl.$path.'?access_key=' . $this->apiKey;
 
         foreach ($queryParams as $param => $value) {
             $url .= '&'.urlencode($param).'='.urlencode($value);


### PR DESCRIPTION
- RequestBuilder: Add a `baseUrl` property and implement usage of the API KEY
- Add configuration details in `README`