### PR TITLE
Rename "ExchangeRatesApiLegacy" driver to "ExchangeRatesApiIo".

### DIFF
--- a/config/laravel-exchange-rates.php
+++ b/config/laravel-exchange-rates.php
@@ -9,10 +9,10 @@ return [
     |
     | Define which API service should be used to retrieve the exchange rates.
     |
-    | Supported: "exchangeratesapi-legacy", "exchange-rates-data-api"
+    | Supported: "exchange-rates-api-io", "exchange-rates-data-api"
     |
     */
-    'driver' => 'exchangeratesapi-legacy',
+    'driver' => 'exchange-rates-api-io',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Classes/ExchangeRate.php
+++ b/src/Classes/ExchangeRate.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\LaravelExchangeRates\Classes;
 
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy\ExchangeRatesApiLegacyDriver;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\ExchangeRatesDataApiDriver;
 use AshAllenDesign\LaravelExchangeRates\Interfaces\ExchangeRateDriver;
 use Illuminate\Support\Manager;
@@ -16,9 +16,9 @@ class ExchangeRate extends Manager
         return new ExchangeRatesDataApiDriver();
     }
 
-    public function createExchangeRatesApiLegacyDriver(): ExchangeRateDriver
+    public function createExchangeRatesApiIoDriver(): ExchangeRateDriver
     {
-        return new ExchangeRatesApiLegacyDriver();
+        return new ExchangeRatesApiIoDriver();
     }
 
     public function getDefaultDriver()

--- a/src/Drivers/ExchangeRatesApiIo/ExchangeRatesApiIoDriver.php
+++ b/src/Drivers/ExchangeRatesApiIo/ExchangeRatesApiIoDriver.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy;
+namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo;
 
 use AshAllenDesign\LaravelExchangeRates\Classes\CacheRepository;
 use AshAllenDesign\LaravelExchangeRates\Classes\Validation;
@@ -15,7 +15,7 @@ use Exception;
 /**
  * @see https://exchangeratesapi.io/
  */
-class ExchangeRatesApiLegacyDriver implements ExchangeRateDriver
+class ExchangeRatesApiIoDriver implements ExchangeRateDriver
 {
     use InteractsWithCache;
 

--- a/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
+++ b/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy;
+namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo;
 
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;

--- a/tests/Unit/Classes/ExchangeRateTest.php
+++ b/tests/Unit/Classes/ExchangeRateTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Classes;
 
 use AshAllenDesign\LaravelExchangeRates\Classes\ExchangeRate;
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy\ExchangeRatesApiLegacyDriver;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\ExchangeRatesDataApiDriver;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
 
@@ -14,11 +14,11 @@ final class ExchangeRateTest extends TestCase
     /** @test */
     public function correct_default_driver_is_returned(): void
     {
-        config(['laravel-exchange-rates.driver' => 'exchangeratesapi-legacy']);
+        config(['laravel-exchange-rates.driver' => 'exchange-rates-api-io']);
 
         $driver = app(ExchangeRate::class)->driver();
 
-        $this->assertSame(ExchangeRatesApiLegacyDriver::class, $driver::class);
+        $this->assertSame(ExchangeRatesApiIoDriver::class, $driver::class);
     }
 
     /**
@@ -44,7 +44,7 @@ final class ExchangeRateTest extends TestCase
     public function validDriversProvider(): array
     {
         return [
-            ['exchangeratesapi-legacy', ExchangeRatesApiLegacyDriver::class],
+            ['exchange-rates-api-io', ExchangeRatesApiIoDriver::class],
             ['exchange-rates-data-api', ExchangeRatesDataApiDriver::class],
         ];
     }

--- a/tests/Unit/Drivers/ExchangeRatesApiIo/ConvertBetweenDateRangeTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesApiIo/ConvertBetweenDateRangeTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesApiLegacy;
+namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesApiIo;
 
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy\ExchangeRatesApiLegacyDriver;
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\RequestBuilder;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\ExchangeRateException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
@@ -36,7 +36,7 @@ final class ConvertBetweenDateRangeTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForOneSymbol());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->convertBetweenDateRange(100, 'GBP', 'EUR', $fromDate, $toDate);
 
         $this->assertEqualsWithDelta([
@@ -77,7 +77,7 @@ final class ConvertBetweenDateRangeTest extends TestCase
         $requestBuilderMock = Mockery::mock(RequestBuilder::class)->makePartial();
         $requestBuilderMock->expects('makeRequest')->never();
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->convertBetweenDateRange(100, 'GBP', 'EUR', $fromDate, $toDate);
 
         $this->assertEqualsWithDelta([
@@ -122,7 +122,7 @@ final class ConvertBetweenDateRangeTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForOneSymbol());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->shouldBustCache()->convertBetweenDateRange(100, 'GBP', 'EUR', $fromDate, $toDate);
 
         $this->assertEqualsWithDelta([
@@ -164,7 +164,7 @@ final class ConvertBetweenDateRangeTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForMultipleSymbols());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->convertBetweenDateRange(100, 'GBP', ['EUR', 'USD'], $fromDate, $toDate);
 
         $expectedArray = [
@@ -197,7 +197,7 @@ final class ConvertBetweenDateRangeTest extends TestCase
         $requestBuilderMock = Mockery::mock(RequestBuilder::class)->makePartial();
         $requestBuilderMock->expects('makeRequest')->withAnyArgs()->never();
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->convertBetweenDateRange(100, 'EUR', 'EUR', $fromDate, $toDate);
 
         $this->assertEquals([
@@ -225,7 +225,7 @@ final class ConvertBetweenDateRangeTest extends TestCase
         $this->expectException(InvalidDateException::class);
         $this->expectExceptionMessage('The date must be in the past.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->convertBetweenDateRange(100, 'EUR', 'GBP', now()->addMinute(), now()->subDay());
     }
 
@@ -235,7 +235,7 @@ final class ConvertBetweenDateRangeTest extends TestCase
         $this->expectException(InvalidDateException::class);
         $this->expectExceptionMessage('The date must be in the past.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->convertBetweenDateRange(100, 'EUR', 'GBP', now()->subDay(), now()->addMinute());
     }
 
@@ -245,7 +245,7 @@ final class ConvertBetweenDateRangeTest extends TestCase
         $this->expectException(InvalidDateException::class);
         $this->expectExceptionMessage("The 'from' date must be before the 'to' date.");
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->convertBetweenDateRange(100, 'EUR', 'GBP', now()->subDay(), now()->subWeek());
     }
 
@@ -255,7 +255,7 @@ final class ConvertBetweenDateRangeTest extends TestCase
         $this->expectException(InvalidCurrencyException::class);
         $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->convertBetweenDateRange(100, 'INVALID', 'GBP', now()->subWeek(), now()->subDay());
     }
 
@@ -265,7 +265,7 @@ final class ConvertBetweenDateRangeTest extends TestCase
         $this->expectException(InvalidCurrencyException::class);
         $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->convertBetweenDateRange(100, 'GBP', 'INVALID', now()->subWeek(), now()->subDay());
     }
 
@@ -275,7 +275,7 @@ final class ConvertBetweenDateRangeTest extends TestCase
         $this->expectException(ExchangeRateException::class);
         $this->expectExceptionMessage('123 is not a string or array.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->convertBetweenDateRange(100, 'GBP', 123, now()->subWeek(), now()->subDay());
     }
 

--- a/tests/Unit/Drivers/ExchangeRatesApiIo/ConvertTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesApiIo/ConvertTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesApiLegacy;
+namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesApiIo;
 
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy\ExchangeRatesApiLegacyDriver;
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\RequestBuilder;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\ExchangeRateException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
@@ -24,7 +24,7 @@ final class ConvertTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForCurrentDateAndOneSymbol());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->convert(100, 'EUR', 'GBP');
         $this->assertEquals('86.158', $rate);
         $this->assertEquals('0.86158', Cache::get('laravel_xr_EUR_GBP_'.now()->format('Y-m-d')));
@@ -41,7 +41,7 @@ final class ConvertTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForPastDateAndOneSymbol());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->convert(100, 'EUR', 'GBP', $mockDate);
         $this->assertEquals('87.053', $rate);
         $this->assertEquals('0.87053', Cache::get('laravel_xr_EUR_GBP_'.$mockDate->format('Y-m-d')));
@@ -57,7 +57,7 @@ final class ConvertTest extends TestCase
         $requestBuilderMock = Mockery::mock(RequestBuilder::class);
         $requestBuilderMock->expects('makeRequest')->never();
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->convert(100, 'EUR', 'GBP', $mockDate);
         $this->assertEquals('12.3456', $rate);
         $this->assertEquals('0.123456', Cache::get('laravel_xr_EUR_GBP_'.$mockDate->format('Y-m-d')));
@@ -76,7 +76,7 @@ final class ConvertTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForPastDateAndOneSymbol());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->shouldBustCache()->convert(100, 'EUR', 'GBP', $mockDate);
         $this->assertEquals('87.053', $rate);
         $this->assertEquals('0.87053', Cache::get('laravel_xr_EUR_GBP_'.$mockDate->format('Y-m-d')));
@@ -88,7 +88,7 @@ final class ConvertTest extends TestCase
         $requestBuilderMock = Mockery::mock(RequestBuilder::class);
         $requestBuilderMock->expects('makeRequest')->withAnyArgs()->never();
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->convert(100, 'EUR', 'EUR');
         $this->assertEquals('100', $rate);
     }
@@ -102,7 +102,7 @@ final class ConvertTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForCurrentDateAndMultipleSymbols());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->convert(100, 'EUR', ['GBP', 'USD', 'CAD']);
 
         $this->assertEqualsWithDelta(['CAD' => 145.61, 'USD' => 110.34, 'GBP' => 86.158], $rate, self::FLOAT_DELTA);
@@ -119,7 +119,7 @@ final class ConvertTest extends TestCase
         $this->expectException(InvalidDateException::class);
         $this->expectExceptionMessage('The date must be in the past.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->convert(100, 'EUR', 'GBP', now()->addMinute());
     }
 
@@ -129,7 +129,7 @@ final class ConvertTest extends TestCase
         $this->expectException(InvalidCurrencyException::class);
         $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->convert(100, 'INVALID', 'GBP', now()->subMinute());
     }
 
@@ -139,7 +139,7 @@ final class ConvertTest extends TestCase
         $this->expectException(InvalidCurrencyException::class);
         $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->convert(100, 'GBP', 'INVALID', now()->subMinute());
     }
 
@@ -149,7 +149,7 @@ final class ConvertTest extends TestCase
         $this->expectException(ExchangeRateException::class);
         $this->expectExceptionMessage('123 is not a string or array.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->convert(10, 'GBP', 123);
     }
 

--- a/tests/Unit/Drivers/ExchangeRatesApiIo/CurrenciesTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesApiIo/CurrenciesTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesApiLegacy;
+namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesApiIo;
 
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy\ExchangeRatesApiLegacyDriver;
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\RequestBuilder;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
@@ -21,7 +21,7 @@ final class CurrenciesTest extends TestCase
             ->once()
             ->andReturn($this->mockResponse());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->currencies();
 
         $this->assertEquals($this->expectedResponse(), $currencies);
@@ -37,7 +37,7 @@ final class CurrenciesTest extends TestCase
         $requestBuilderMock = Mockery::mock(RequestBuilder::class)->makePartial();
         $requestBuilderMock->expects('makeRequest')->never();
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->currencies();
 
         $this->assertEquals(['CUR1', 'CUR2', 'CUR3'], $currencies);
@@ -54,7 +54,7 @@ final class CurrenciesTest extends TestCase
             ->once()
             ->andReturn($this->mockResponse());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->shouldBustCache()->currencies();
 
         $this->assertEquals($this->expectedResponse(), $currencies);
@@ -69,7 +69,7 @@ final class CurrenciesTest extends TestCase
             ->once()
             ->andReturn($this->mockResponse());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->shouldCache(false)->currencies();
 
         $this->assertEquals($this->expectedResponse(), $currencies);

--- a/tests/Unit/Drivers/ExchangeRatesApiIo/ExchangeRateBetweenDateRangeTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesApiIo/ExchangeRateBetweenDateRangeTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesApiLegacy;
+namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesApiIo;
 
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy\ExchangeRatesApiLegacyDriver;
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\RequestBuilder;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\ExchangeRateException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
@@ -36,7 +36,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForOneSymbol());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->exchangeRateBetweenDateRange('GBP', 'EUR', $fromDate, $toDate);
 
         $expectedArray = [
@@ -71,7 +71,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
         $requestBuilderMock = Mockery::mock(RequestBuilder::class)->makePartial();
         $requestBuilderMock->expects('makeRequest')->never();
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->exchangeRateBetweenDateRange('GBP', 'EUR', $fromDate, $toDate);
 
         $this->assertEquals($expectedArray, $currencies);
@@ -109,7 +109,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForOneSymbol());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->shouldBustCache()->exchangeRateBetweenDateRange('GBP', 'EUR', $fromDate, $toDate);
 
         $expectedArray = [
@@ -145,7 +145,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForOneSymbol());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->shouldCache(false)->exchangeRateBetweenDateRange('GBP', 'EUR', $fromDate, $toDate);
 
         $expectedArray = [
@@ -180,7 +180,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForMultipleSymbols());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->exchangeRateBetweenDateRange('GBP', ['EUR', 'USD'], $fromDate, $toDate);
 
         $expectedArray = [
@@ -206,7 +206,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
         $requestBuilderMock = Mockery::mock(RequestBuilder::class)->makePartial();
         $requestBuilderMock->expects('makeRequest')->withAnyArgs()->never();
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $currencies = $exchangeRate->exchangeRateBetweenDateRange('EUR', 'EUR', $fromDate, $toDate);
 
         $expectedArray = [
@@ -229,7 +229,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
         $this->expectException(InvalidDateException::class);
         $this->expectExceptionMessage('The date must be in the past.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRateBetweenDateRange('EUR', 'GBP', now()->addMinute(), now()->subDay());
     }
 
@@ -239,7 +239,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
         $this->expectException(InvalidDateException::class);
         $this->expectExceptionMessage('The date must be in the past.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRateBetweenDateRange('EUR', 'GBP', now()->subDay(), now()->addMinute());
     }
 
@@ -249,7 +249,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
         $this->expectException(InvalidDateException::class);
         $this->expectExceptionMessage("The 'from' date must be before the 'to' date.");
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRateBetweenDateRange('EUR', 'GBP', now()->subDay(), now()->subWeek());
     }
 
@@ -259,7 +259,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
         $this->expectException(InvalidCurrencyException::class);
         $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRateBetweenDateRange('INVALID', 'GBP', now()->subWeek(), now()->subDay());
     }
 
@@ -269,7 +269,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
         $this->expectException(InvalidCurrencyException::class);
         $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRateBetweenDateRange('GBP', 'INVALID', now()->subWeek(), now()->subDay());
     }
 
@@ -279,7 +279,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
         $this->expectException(InvalidCurrencyException::class);
         $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRateBetweenDateRange('GBP', ['USD', 'INVALID'], now()->subWeek(), now()->subDay());
     }
 
@@ -289,7 +289,7 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
         $this->expectException(ExchangeRateException::class);
         $this->expectExceptionMessage('123 is not a string or array.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRateBetweenDateRange('GBP', 123, now()->subWeek(), now()->subDay());
     }
 

--- a/tests/Unit/Drivers/ExchangeRatesApiIo/ExchangeRateTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesApiIo/ExchangeRateTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesApiLegacy;
+namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesApiIo;
 
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy\ExchangeRatesApiLegacyDriver;
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApILegacy\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\RequestBuilder;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\ExchangeRateException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
@@ -25,7 +25,7 @@ final class ExchangeRateTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForCurrentDateAndOneSymbol());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->exchangeRate('EUR', 'GBP');
         $this->assertEquals('0.86158', $rate);
         $this->assertEquals('0.86158', Cache::get('laravel_xr_EUR_GBP_'.now()->format('Y-m-d')));
@@ -42,7 +42,7 @@ final class ExchangeRateTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForPastDateAndOneSymbol());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->exchangeRate('EUR', 'GBP', $mockDate);
         $this->assertEquals('0.87053', $rate);
         $this->assertEquals('0.87053', Cache::get('laravel_xr_EUR_GBP_'.$mockDate->format('Y-m-d')));
@@ -58,7 +58,7 @@ final class ExchangeRateTest extends TestCase
         $requestBuilderMock = Mockery::mock(RequestBuilder::class);
         $requestBuilderMock->expects('makeRequest')->never();
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->exchangeRate('EUR', 'GBP', $mockDate);
         $this->assertEquals('0.123456', $rate);
         $this->assertEquals('0.123456', Cache::get('laravel_xr_EUR_GBP_'.$mockDate->format('Y-m-d')));
@@ -73,7 +73,7 @@ final class ExchangeRateTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForCurrentDateAndMultipleSymbols());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $response = $exchangeRate->exchangeRate('EUR', ['GBP', 'USD', 'CAD']);
         $this->assertEquals(['CAD' => 1.4561, 'USD' => 1.1034, 'GBP' => 0.86158], $response);
         $this->assertEquals(
@@ -93,7 +93,7 @@ final class ExchangeRateTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForPastDateAndMultipleSymbols());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $response = $exchangeRate->exchangeRate('EUR', ['GBP', 'CAD', 'USD'], $mockDate);
         $this->assertEquals(['CAD' => 1.4969, 'USD' => 1.1346, 'GBP' => 0.87053], $response);
         $this->assertEquals(
@@ -116,7 +116,7 @@ final class ExchangeRateTest extends TestCase
         $requestBuilderMock = Mockery::mock(RequestBuilder::class);
         $requestBuilderMock->expects('makeRequest')->never();
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->exchangeRate('EUR', ['GBP', 'USD', 'CAD'], $mockDate);
         $this->assertEquals(['CAD' => 1.4561, 'USD' => 1.1034, 'GBP' => 0.86158], $rate);
         $this->assertEquals(
@@ -138,7 +138,7 @@ final class ExchangeRateTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForPastDateAndOneSymbol());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->shouldBustCache()->exchangeRate('EUR', 'GBP', $mockDate);
         $this->assertEquals('0.87053', $rate);
         $this->assertEquals('0.87053', Cache::get('laravel_xr_EUR_GBP_'.$mockDate->format('Y-m-d')));
@@ -153,7 +153,7 @@ final class ExchangeRateTest extends TestCase
             ->once()
             ->andReturn($this->mockResponseForCurrentDateAndOneSymbol());
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->shouldCache(false)->exchangeRate('EUR', 'GBP');
         $this->assertEquals('0.86158', $rate);
         $this->assertNull(Cache::get('laravel_xr_EUR_GBP_'.now()->format('Y-m-d')));
@@ -165,7 +165,7 @@ final class ExchangeRateTest extends TestCase
         $requestBuilderMock = Mockery::mock(RequestBuilder::class);
         $requestBuilderMock->expects('makeRequest')->withAnyArgs()->never();
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver($requestBuilderMock);
+        $exchangeRate = new ExchangeRatesApiIoDriver($requestBuilderMock);
         $rate = $exchangeRate->exchangeRate('EUR', 'EUR');
         $this->assertEquals(1.0, $rate);
     }
@@ -176,7 +176,7 @@ final class ExchangeRateTest extends TestCase
         $this->expectException(InvalidDateException::class);
         $this->expectExceptionMessage('The date must be in the past.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRate('EUR', 'GBP', now()->addMinute());
     }
 
@@ -186,7 +186,7 @@ final class ExchangeRateTest extends TestCase
         $this->expectException(InvalidCurrencyException::class);
         $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRate('INVALID', 'GBP', now()->subMinute());
     }
 
@@ -196,7 +196,7 @@ final class ExchangeRateTest extends TestCase
         $this->expectException(InvalidCurrencyException::class);
         $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRate('GBP', 'INVALID', now()->subMinute());
     }
 
@@ -206,7 +206,7 @@ final class ExchangeRateTest extends TestCase
         $this->expectException(InvalidDateException::class);
         $this->expectExceptionMessage('The date cannot be before 4th January 1999.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRate('GBP', 'USD', Carbon::createFromDate(1999, 1, 3));
     }
 
@@ -216,7 +216,7 @@ final class ExchangeRateTest extends TestCase
         $this->expectException(InvalidCurrencyException::class);
         $this->expectExceptionMessage('INVALID is not a valid currency code.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRate('GBP', ['INVALID'], now()->subMinute());
     }
 
@@ -226,7 +226,7 @@ final class ExchangeRateTest extends TestCase
         $this->expectException(ExchangeRateException::class);
         $this->expectExceptionMessage('123 is not a string or array.');
 
-        $exchangeRate = new ExchangeRatesApiLegacyDriver();
+        $exchangeRate = new ExchangeRatesApiIoDriver();
         $exchangeRate->exchangeRate('GBP', 123, now()->subMinute());
     }
 


### PR DESCRIPTION
I'm renaming this because I think it fits the description of the service better