### PR TITLE
Dry up code

### DIFF
--- a/src/Drivers/ExchangeRatesApiIo/ExchangeRatesApiIoDriver.php
+++ b/src/Drivers/ExchangeRatesApiIo/ExchangeRatesApiIoDriver.php
@@ -3,8 +3,7 @@
 namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo;
 
 use AshAllenDesign\LaravelExchangeRates\Classes\CacheRepository;
-use AshAllenDesign\LaravelExchangeRates\Classes\Validation;
-use AshAllenDesign\LaravelExchangeRates\Concerns\InteractsWithCache;
+use AshAllenDesign\LaravelExchangeRates\Drivers\Support\SharedDriverLogicHandler;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\ExchangeRateException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
@@ -17,38 +16,7 @@ use Exception;
  */
 class ExchangeRatesApiIoDriver implements ExchangeRateDriver
 {
-    use InteractsWithCache;
-
-    /**
-     * The object used for making requests to the currency
-     * conversion API.
-     *
-     * @var RequestBuilder
-     */
-    private $requestBuilder;
-
-    /**
-     * The repository used for accessing the cache.
-     *
-     * @var CacheRepository
-     */
-    private $cacheRepository;
-
-    /**
-     * Whether of not the exchange rate should be cached
-     * after being fetched from the API.
-     *
-     * @var bool
-     */
-    private $shouldCache = true;
-
-    /**
-     * Whether or not the cache should be busted and a new
-     * value should be fetched from the API.
-     *
-     * @var bool
-     */
-    private $shouldBustCache = false;
+    private SharedDriverLogicHandler $sharedDriverLogicHandler;
 
     /**
      * ExchangeRate constructor.
@@ -58,8 +26,13 @@ class ExchangeRatesApiIoDriver implements ExchangeRateDriver
      */
     public function __construct(RequestBuilder $requestBuilder = null, CacheRepository $cacheRepository = null)
     {
-        $this->requestBuilder = $requestBuilder ?? new RequestBuilder();
-        $this->cacheRepository = $cacheRepository ?? new CacheRepository();
+        $requestBuilder = $requestBuilder ?? new RequestBuilder();
+        $cacheRepository = $cacheRepository ?? new CacheRepository();
+
+        $this->sharedDriverLogicHandler = new SharedDriverLogicHandler(
+            $requestBuilder,
+            $cacheRepository
+        );
     }
 
     /**
@@ -71,25 +44,7 @@ class ExchangeRatesApiIoDriver implements ExchangeRateDriver
      */
     public function currencies(array $currencies = []): array
     {
-        $cacheKey = 'currencies';
-
-        if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {
-            return $cachedExchangeRate;
-        }
-
-        $response = $this->requestBuilder->makeRequest('/latest', []);
-
-        $currencies[] = $response['base'];
-
-        foreach ($response['rates'] as $currency => $rate) {
-            $currencies[] = $currency;
-        }
-
-        if ($this->shouldCache) {
-            $this->cacheRepository->storeInCache($cacheKey, $currencies);
-        }
-
-        return $currencies;
+        return $this->sharedDriverLogicHandler->currencies($currencies);
     }
 
     /**
@@ -111,42 +66,7 @@ class ExchangeRatesApiIoDriver implements ExchangeRateDriver
      */
     public function exchangeRate(string $from, $to, Carbon $date = null)
     {
-        Validation::validateIsStringOrArray($to);
-
-        if ($date) {
-            Validation::validateDate($date);
-        }
-
-        Validation::validateCurrencyCode($from);
-
-        is_string($to) ? Validation::validateCurrencyCode($to) : Validation::validateCurrencyCodes($to);
-
-        if ($from === $to) {
-            return 1.0;
-        }
-
-        $cacheKey = $this->cacheRepository->buildCacheKey($from, $to, $date ?? Carbon::now());
-
-        if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {
-            return $cachedExchangeRate;
-        }
-
-        $symbols = is_string($to) ? $to : implode(',', $to);
-        $queryParams = ['base' => $from, 'symbols' => $symbols];
-
-        $url = $date
-            ? '/'.$date->format('Y-m-d')
-            : '/latest';
-
-        $response = $this->requestBuilder->makeRequest($url, $queryParams)['rates'];
-
-        $exchangeRate = is_string($to) ? $response[$to] : $response;
-
-        if ($this->shouldCache) {
-            $this->cacheRepository->storeInCache($cacheKey, $exchangeRate);
-        }
-
-        return $exchangeRate;
+        return $this->sharedDriverLogicHandler->exchangeRate($from, $to, $date);
     }
 
     /**
@@ -164,69 +84,12 @@ class ExchangeRatesApiIoDriver implements ExchangeRateDriver
      */
     public function exchangeRateBetweenDateRange(
         string $from,
-        $to,
+               $to,
         Carbon $date,
         Carbon $endDate,
         array $conversions = []
     ): array {
-        Validation::validateCurrencyCode($from);
-        Validation::validateStartAndEndDates($date, $endDate);
-        Validation::validateIsStringOrArray($to);
-
-        is_string($to) ? Validation::validateCurrencyCode($to) : Validation::validateCurrencyCodes($to);
-
-        $cacheKey = $this->cacheRepository->buildCacheKey($from, $to, $date, $endDate);
-
-        if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {
-            return $cachedExchangeRate;
-        }
-
-        $conversions = $from === $to
-            ? $this->exchangeRateDateRangeResultWithSameCurrency($date, $endDate, $conversions)
-            : $conversions = $this->makeRequestForExchangeRates($from, $to, $date, $endDate);
-
-        if ($this->shouldCache) {
-            $this->cacheRepository->storeInCache($cacheKey, $conversions);
-        }
-
-        return $conversions;
-    }
-
-    /**
-     * Make a request to the Exchange Rates API to get the
-     * exchange rates between a date range. If only one
-     * currency is being used, we flatten the array
-     * to remove currency symbol before returning
-     * it.
-     *
-     * @param  string  $from
-     * @param  string|array  $to
-     * @param  Carbon  $date
-     * @param  Carbon  $endDate
-     * @return array
-     */
-    private function makeRequestForExchangeRates(string $from, $to, Carbon $date, Carbon $endDate): array
-    {
-        $symbols = is_string($to) ? $to : implode(',', $to);
-
-        $result = $this->requestBuilder->makeRequest('/timeseries', [
-            'base'     => $from,
-            'start_date' => $date->format('Y-m-d'),
-            'end_date'   => $endDate->format('Y-m-d'),
-            'symbols'  => $symbols,
-        ]);
-
-        $conversions = $result['rates'];
-
-        if (is_string($to)) {
-            foreach ($conversions as $date => $rate) {
-                $conversions[$date] = $rate[$to];
-            }
-        }
-
-        ksort($conversions);
-
-        return $conversions;
+        return $this->sharedDriverLogicHandler->exchangeRateBetweenDateRange($from, $to, $date, $endDate, $conversions);
     }
 
     /**
@@ -246,17 +109,7 @@ class ExchangeRatesApiIoDriver implements ExchangeRateDriver
      */
     public function convert(int $value, string $from, $to, Carbon $date = null)
     {
-        if (is_string($to)) {
-            return (float) $this->exchangeRate($from, $to, $date) * $value;
-        }
-
-        $exchangeRates = $this->exchangeRate($from, $to, $date);
-
-        foreach ($exchangeRates as $currency => $exchangeRate) {
-            $exchangeRates[$currency] = (float) $exchangeRate * $value;
-        }
-
-        return $exchangeRates;
+        return $this->sharedDriverLogicHandler->convert($value, $from, $to, $date);
     }
 
     /**
@@ -281,47 +134,20 @@ class ExchangeRatesApiIoDriver implements ExchangeRateDriver
         Carbon $endDate,
         array $conversions = []
     ): array {
-        $exchangeRates = $this->exchangeRateBetweenDateRange($from, $to, $date, $endDate);
-
-        if (is_array($to)) {
-            foreach ($exchangeRates as $date => $exchangeRate) {
-                foreach ($exchangeRate as $currency => $rate) {
-                    $conversions[$date][$currency] = (float) $rate * $value;
-                }
-            }
-
-            return $conversions;
-        }
-
-        foreach ($exchangeRates as $date => $exchangeRate) {
-            $conversions[$date] = (float) $exchangeRate * $value;
-        }
-
-        return $conversions;
+        return $this->sharedDriverLogicHandler->convertBetweenDateRange($value, $from, $to, $date, $endDate, $conversions);
     }
 
-    /**
-     * If the 'from' and 'to' currencies are the same, we
-     * don't need to make a request to the API. Instead,
-     * we can build the response ourselves to improve
-     * the performance.
-     *
-     * @param  Carbon  $startDate
-     * @param  Carbon  $endDate
-     * @param  array  $conversions
-     * @return array
-     */
-    private function exchangeRateDateRangeResultWithSameCurrency(
-        Carbon $startDate,
-        Carbon $endDate,
-        array $conversions = []
-    ): array {
-        for ($date = clone $startDate; $date->lte($endDate); $date->addDay()) {
-            if ($date->isWeekday()) {
-                $conversions[$date->format('Y-m-d')] = 1.0;
-            }
-        }
+    public function shouldCache(bool $shouldCache = true): ExchangeRateDriver
+    {
+        $this->sharedDriverLogicHandler->shouldCache($shouldCache);
 
-        return $conversions;
+        return $this;
+    }
+
+    public function shouldBustCache(bool $bustCache = true): ExchangeRateDriver
+    {
+        $this->sharedDriverLogicHandler->shouldBustCache($bustCache);
+
+        return $this;
     }
 }

--- a/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
+++ b/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
@@ -2,10 +2,11 @@
 
 namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo;
 
+use AshAllenDesign\LaravelExchangeRates\Interfaces\RequestSender;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 
-class RequestBuilder
+class RequestBuilder implements RequestSender
 {
     private const BASE_URL = 'https://api.exchangeratesapi.io/v1/';
 

--- a/src/Drivers/ExchangeRatesDataApi/ExchangeRatesDataApiDriver.php
+++ b/src/Drivers/ExchangeRatesDataApi/ExchangeRatesDataApiDriver.php
@@ -3,8 +3,7 @@
 namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi;
 
 use AshAllenDesign\LaravelExchangeRates\Classes\CacheRepository;
-use AshAllenDesign\LaravelExchangeRates\Classes\Validation;
-use AshAllenDesign\LaravelExchangeRates\Concerns\InteractsWithCache;
+use AshAllenDesign\LaravelExchangeRates\Drivers\Support\SharedDriverLogicHandler;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\ExchangeRateException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
@@ -17,38 +16,7 @@ use Exception;
  */
 class ExchangeRatesDataApiDriver implements ExchangeRateDriver
 {
-    use InteractsWithCache;
-
-    /**
-     * The object used for making requests to the currency
-     * conversion API.
-     *
-     * @var RequestBuilder
-     */
-    private $requestBuilder;
-
-    /**
-     * The repository used for accessing the cache.
-     *
-     * @var CacheRepository
-     */
-    private $cacheRepository;
-
-    /**
-     * Whether of not the exchange rate should be cached
-     * after being fetched from the API.
-     *
-     * @var bool
-     */
-    private $shouldCache = true;
-
-    /**
-     * Whether or not the cache should be busted and a new
-     * value should be fetched from the API.
-     *
-     * @var bool
-     */
-    private $shouldBustCache = false;
+    private SharedDriverLogicHandler $sharedDriverLogicHandler;
 
     /**
      * ExchangeRate constructor.
@@ -58,8 +26,13 @@ class ExchangeRatesDataApiDriver implements ExchangeRateDriver
      */
     public function __construct(RequestBuilder $requestBuilder = null, CacheRepository $cacheRepository = null)
     {
-        $this->requestBuilder = $requestBuilder ?? new RequestBuilder();
-        $this->cacheRepository = $cacheRepository ?? new CacheRepository();
+        $requestBuilder = $requestBuilder ?? new RequestBuilder();
+        $cacheRepository = $cacheRepository ?? new CacheRepository();
+
+        $this->sharedDriverLogicHandler = new SharedDriverLogicHandler(
+            $requestBuilder,
+            $cacheRepository
+        );
     }
 
     /**
@@ -71,25 +44,7 @@ class ExchangeRatesDataApiDriver implements ExchangeRateDriver
      */
     public function currencies(array $currencies = []): array
     {
-        $cacheKey = 'currencies';
-
-        if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {
-            return $cachedExchangeRate;
-        }
-
-        $response = $this->requestBuilder->makeRequest('/latest', []);
-
-        $currencies[] = $response['base'];
-
-        foreach ($response['rates'] as $currency => $rate) {
-            $currencies[] = $currency;
-        }
-
-        if ($this->shouldCache) {
-            $this->cacheRepository->storeInCache($cacheKey, $currencies);
-        }
-
-        return $currencies;
+        return $this->sharedDriverLogicHandler->currencies($currencies);
     }
 
     /**
@@ -111,42 +66,7 @@ class ExchangeRatesDataApiDriver implements ExchangeRateDriver
      */
     public function exchangeRate(string $from, $to, Carbon $date = null)
     {
-        Validation::validateIsStringOrArray($to);
-
-        if ($date) {
-            Validation::validateDate($date);
-        }
-
-        Validation::validateCurrencyCode($from);
-
-        is_string($to) ? Validation::validateCurrencyCode($to) : Validation::validateCurrencyCodes($to);
-
-        if ($from === $to) {
-            return 1.0;
-        }
-
-        $cacheKey = $this->cacheRepository->buildCacheKey($from, $to, $date ?? Carbon::now());
-
-        if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {
-            return $cachedExchangeRate;
-        }
-
-        $symbols = is_string($to) ? $to : implode(',', $to);
-        $queryParams = ['base' => $from, 'symbols' => $symbols];
-
-        $url = $date
-            ? '/'.$date->format('Y-m-d')
-            : '/latest';
-
-        $response = $this->requestBuilder->makeRequest($url, $queryParams)['rates'];
-
-        $exchangeRate = is_string($to) ? $response[$to] : $response;
-
-        if ($this->shouldCache) {
-            $this->cacheRepository->storeInCache($cacheKey, $exchangeRate);
-        }
-
-        return $exchangeRate;
+        return $this->sharedDriverLogicHandler->exchangeRate($from, $to, $date);
     }
 
     /**
@@ -169,64 +89,7 @@ class ExchangeRatesDataApiDriver implements ExchangeRateDriver
         Carbon $endDate,
         array $conversions = []
     ): array {
-        Validation::validateCurrencyCode($from);
-        Validation::validateStartAndEndDates($date, $endDate);
-        Validation::validateIsStringOrArray($to);
-
-        is_string($to) ? Validation::validateCurrencyCode($to) : Validation::validateCurrencyCodes($to);
-
-        $cacheKey = $this->cacheRepository->buildCacheKey($from, $to, $date, $endDate);
-
-        if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {
-            return $cachedExchangeRate;
-        }
-
-        $conversions = $from === $to
-            ? $this->exchangeRateDateRangeResultWithSameCurrency($date, $endDate, $conversions)
-            : $conversions = $this->makeRequestForExchangeRates($from, $to, $date, $endDate);
-
-        if ($this->shouldCache) {
-            $this->cacheRepository->storeInCache($cacheKey, $conversions);
-        }
-
-        return $conversions;
-    }
-
-    /**
-     * Make a request to the Exchange Rates API to get the
-     * exchange rates between a date range. If only one
-     * currency is being used, we flatten the array
-     * to remove currency symbol before returning
-     * it.
-     *
-     * @param  string  $from
-     * @param  string|array  $to
-     * @param  Carbon  $date
-     * @param  Carbon  $endDate
-     * @return array
-     */
-    private function makeRequestForExchangeRates(string $from, $to, Carbon $date, Carbon $endDate): array
-    {
-        $symbols = is_string($to) ? $to : implode(',', $to);
-
-        $result = $this->requestBuilder->makeRequest('/timeseries', [
-            'base'     => $from,
-            'start_date' => $date->format('Y-m-d'),
-            'end_date'   => $endDate->format('Y-m-d'),
-            'symbols'  => $symbols,
-        ]);
-
-        $conversions = $result['rates'];
-
-        if (is_string($to)) {
-            foreach ($conversions as $date => $rate) {
-                $conversions[$date] = $rate[$to];
-            }
-        }
-
-        ksort($conversions);
-
-        return $conversions;
+        return $this->sharedDriverLogicHandler->exchangeRateBetweenDateRange($from, $to, $date, $endDate, $conversions);
     }
 
     /**
@@ -246,17 +109,7 @@ class ExchangeRatesDataApiDriver implements ExchangeRateDriver
      */
     public function convert(int $value, string $from, $to, Carbon $date = null)
     {
-        if (is_string($to)) {
-            return (float) $this->exchangeRate($from, $to, $date) * $value;
-        }
-
-        $exchangeRates = $this->exchangeRate($from, $to, $date);
-
-        foreach ($exchangeRates as $currency => $exchangeRate) {
-            $exchangeRates[$currency] = (float) $exchangeRate * $value;
-        }
-
-        return $exchangeRates;
+        return $this->sharedDriverLogicHandler->convert($value, $from, $to, $date);
     }
 
     /**
@@ -281,47 +134,20 @@ class ExchangeRatesDataApiDriver implements ExchangeRateDriver
         Carbon $endDate,
         array $conversions = []
     ): array {
-        $exchangeRates = $this->exchangeRateBetweenDateRange($from, $to, $date, $endDate);
-
-        if (is_array($to)) {
-            foreach ($exchangeRates as $date => $exchangeRate) {
-                foreach ($exchangeRate as $currency => $rate) {
-                    $conversions[$date][$currency] = (float) $rate * $value;
-                }
-            }
-
-            return $conversions;
-        }
-
-        foreach ($exchangeRates as $date => $exchangeRate) {
-            $conversions[$date] = (float) $exchangeRate * $value;
-        }
-
-        return $conversions;
+        return $this->sharedDriverLogicHandler->convertBetweenDateRange($value, $from, $to, $date, $endDate, $conversions);
     }
 
-    /**
-     * If the 'from' and 'to' currencies are the same, we
-     * don't need to make a request to the API. Instead,
-     * we can build the response ourselves to improve
-     * the performance.
-     *
-     * @param  Carbon  $startDate
-     * @param  Carbon  $endDate
-     * @param  array  $conversions
-     * @return array
-     */
-    private function exchangeRateDateRangeResultWithSameCurrency(
-        Carbon $startDate,
-        Carbon $endDate,
-        array $conversions = []
-    ): array {
-        for ($date = clone $startDate; $date->lte($endDate); $date->addDay()) {
-            if ($date->isWeekday()) {
-                $conversions[$date->format('Y-m-d')] = 1.0;
-            }
-        }
+    public function shouldCache(bool $shouldCache = true): ExchangeRateDriver
+    {
+        $this->sharedDriverLogicHandler->shouldCache($shouldCache);
 
-        return $conversions;
+        return $this;
+    }
+
+    public function shouldBustCache(bool $bustCache = true): ExchangeRateDriver
+    {
+        $this->sharedDriverLogicHandler->shouldBustCache($bustCache);
+
+        return $this;
     }
 }

--- a/src/Drivers/ExchangeRatesDataApi/RequestBuilder.php
+++ b/src/Drivers/ExchangeRatesDataApi/RequestBuilder.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi;
 
+use AshAllenDesign\LaravelExchangeRates\Interfaces\RequestSender;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 
-class RequestBuilder
+class RequestBuilder implements RequestSender
 {
     private const BASE_URL = 'https://api.apilayer.com/exchangerates_data/';
 
@@ -19,7 +20,7 @@ class RequestBuilder
     }
 
     /**
-     * Make an API request to the ExchangeRatesAPI.
+     * Make an API request to the Exchange Rates Data API.
      *
      * @param  string  $path
      * @param  string[]  $queryParams

--- a/src/Drivers/Support/SharedDriverLogicHandler.php
+++ b/src/Drivers/Support/SharedDriverLogicHandler.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AshAllenDesign\LaravelExchangeRates\Drivers\Support;
+
+use AshAllenDesign\LaravelExchangeRates\Classes\CacheRepository;
+use AshAllenDesign\LaravelExchangeRates\Classes\Validation;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Exceptions\ExchangeRateException;
+use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
+use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
+use Carbon\Carbon;
+
+class SharedDriverLogicHandler
+{
+    /**
+     * The object used for making requests to the currency
+     * conversion API.
+     *
+     * @var RequestBuilder
+     */
+    private $requestBuilder;
+
+    /**
+     * The repository used for accessing the cache.
+     *
+     * @var CacheRepository
+     */
+    private $cacheRepository;
+
+    /**
+     * Whether of not the exchange rate should be cached
+     * after being fetched from the API.
+     *
+     * @var bool
+     */
+    private $shouldCache = true;
+
+    /**
+     * Whether or not the cache should be busted and a new
+     * value should be fetched from the API.
+     *
+     * @var bool
+     */
+    private $shouldBustCache = false;
+
+    /**
+     * ExchangeRate constructor.
+     *
+     * @param  RequestBuilder|null  $requestBuilder
+     * @param  CacheRepository|null  $cacheRepository
+     */
+    // TODO Add type hinting for the request builder.
+    public function __construct($requestBuilder = null, CacheRepository $cacheRepository = null)
+    {
+        $this->requestBuilder = $requestBuilder ?? new RequestBuilder();
+        $this->cacheRepository = $cacheRepository ?? new CacheRepository();
+    }
+
+    /**
+     * Return an array of available currencies that
+     * can be used with this package.
+     *
+     * @param  array  $currencies
+     * @return array
+     */
+    public function currencies(array $currencies = []): array
+    {
+        $cacheKey = 'currencies';
+
+        if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {
+            return $cachedExchangeRate;
+        }
+
+        $response = $this->requestBuilder->makeRequest('/latest', []);
+
+        $currencies[] = $response['base'];
+
+        foreach ($response['rates'] as $currency => $rate) {
+            $currencies[] = $currency;
+        }
+
+        if ($this->shouldCache) {
+            $this->cacheRepository->storeInCache($cacheKey, $currencies);
+        }
+
+        return $currencies;
+    }
+
+    /**
+     * Return the exchange rate between the $from and $to
+     * parameters. If no $date parameter is passed, we
+     * use today's date instead. If $to is a string,
+     * the exchange rate will be returned as a
+     * string. If $to is an array, the rates
+     * will be returned within an array.
+     *
+     * @param  string  $from
+     * @param  string|array  $to
+     * @param  Carbon|null  $date
+     * @return float|string|array
+     *
+     * @throws InvalidDateException
+     * @throws InvalidCurrencyException
+     * @throws ExchangeRateException
+     */
+    public function exchangeRate(string $from, $to, Carbon $date = null)
+    {
+        Validation::validateIsStringOrArray($to);
+
+        if ($date) {
+            Validation::validateDate($date);
+        }
+
+        Validation::validateCurrencyCode($from);
+
+        is_string($to) ? Validation::validateCurrencyCode($to) : Validation::validateCurrencyCodes($to);
+
+        if ($from === $to) {
+            return 1.0;
+        }
+
+        $cacheKey = $this->cacheRepository->buildCacheKey($from, $to, $date ?? Carbon::now());
+
+        if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {
+            return $cachedExchangeRate;
+        }
+
+        $symbols = is_string($to) ? $to : implode(',', $to);
+        $queryParams = ['base' => $from, 'symbols' => $symbols];
+
+        $url = $date
+            ? '/'.$date->format('Y-m-d')
+            : '/latest';
+
+        $response = $this->requestBuilder->makeRequest($url, $queryParams)['rates'];
+
+        $exchangeRate = is_string($to) ? $response[$to] : $response;
+
+        if ($this->shouldCache) {
+            $this->cacheRepository->storeInCache($cacheKey, $exchangeRate);
+        }
+
+        return $exchangeRate;
+    }
+
+    /**
+     * Return the exchange rates between the given
+     * date range.
+     *
+     * @param  string  $from
+     * @param  string|array  $to
+     * @param  Carbon  $date
+     * @param  Carbon  $endDate
+     * @param  array  $conversions
+     * @return array
+     *
+     * @throws Exception
+     */
+    public function exchangeRateBetweenDateRange(
+        string $from,
+               $to,
+        Carbon $date,
+        Carbon $endDate,
+        array $conversions = []
+    ): array {
+        Validation::validateCurrencyCode($from);
+        Validation::validateStartAndEndDates($date, $endDate);
+        Validation::validateIsStringOrArray($to);
+
+        is_string($to) ? Validation::validateCurrencyCode($to) : Validation::validateCurrencyCodes($to);
+
+        $cacheKey = $this->cacheRepository->buildCacheKey($from, $to, $date, $endDate);
+
+        if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {
+            return $cachedExchangeRate;
+        }
+
+        $conversions = $from === $to
+            ? $this->exchangeRateDateRangeResultWithSameCurrency($date, $endDate, $conversions)
+            : $conversions = $this->makeRequestForExchangeRates($from, $to, $date, $endDate);
+
+        if ($this->shouldCache) {
+            $this->cacheRepository->storeInCache($cacheKey, $conversions);
+        }
+
+        return $conversions;
+    }
+
+    /**
+     * Make a request to the Exchange Rates API to get the
+     * exchange rates between a date range. If only one
+     * currency is being used, we flatten the array
+     * to remove currency symbol before returning
+     * it.
+     *
+     * @param  string  $from
+     * @param  string|array  $to
+     * @param  Carbon  $date
+     * @param  Carbon  $endDate
+     * @return array
+     */
+    private function makeRequestForExchangeRates(string $from, $to, Carbon $date, Carbon $endDate): array
+    {
+        $symbols = is_string($to) ? $to : implode(',', $to);
+
+        $result = $this->requestBuilder->makeRequest('/timeseries', [
+            'base'     => $from,
+            'start_date' => $date->format('Y-m-d'),
+            'end_date'   => $endDate->format('Y-m-d'),
+            'symbols'  => $symbols,
+        ]);
+
+        $conversions = $result['rates'];
+
+        if (is_string($to)) {
+            foreach ($conversions as $date => $rate) {
+                $conversions[$date] = $rate[$to];
+            }
+        }
+
+        ksort($conversions);
+
+        return $conversions;
+    }
+
+    /**
+     * Return the converted values between the $from and $to
+     * parameters. If no $date parameter is passed, we
+     * use today's date instead.
+     *
+     * @param  int  $value
+     * @param  string  $from
+     * @param  string|array  $to
+     * @param  Carbon|null  $date
+     * @return float|array
+     *
+     * @throws InvalidDateException
+     * @throws InvalidCurrencyException
+     * @throws ExchangeRateException
+     */
+    public function convert(int $value, string $from, $to, Carbon $date = null)
+    {
+        if (is_string($to)) {
+            return (float) $this->exchangeRate($from, $to, $date) * $value;
+        }
+
+        $exchangeRates = $this->exchangeRate($from, $to, $date);
+
+        foreach ($exchangeRates as $currency => $exchangeRate) {
+            $exchangeRates[$currency] = (float) $exchangeRate * $value;
+        }
+
+        return $exchangeRates;
+    }
+
+    /**
+     * Return an array of the converted values between the
+     * given date range.
+     *
+     * @param  int  $value
+     * @param  string  $from
+     * @param  string|array  $to
+     * @param  Carbon  $date
+     * @param  Carbon  $endDate
+     * @param  array  $conversions
+     * @return array
+     *
+     * @throws Exception
+     */
+    public function convertBetweenDateRange(
+        int $value,
+        string $from,
+        $to,
+        Carbon $date,
+        Carbon $endDate,
+        array $conversions = []
+    ): array {
+        $exchangeRates = $this->exchangeRateBetweenDateRange($from, $to, $date, $endDate);
+
+        if (is_array($to)) {
+            foreach ($exchangeRates as $date => $exchangeRate) {
+                foreach ($exchangeRate as $currency => $rate) {
+                    $conversions[$date][$currency] = (float) $rate * $value;
+                }
+            }
+
+            return $conversions;
+        }
+
+        foreach ($exchangeRates as $date => $exchangeRate) {
+            $conversions[$date] = (float) $exchangeRate * $value;
+        }
+
+        return $conversions;
+    }
+
+    /**
+     * If the 'from' and 'to' currencies are the same, we
+     * don't need to make a request to the API. Instead,
+     * we can build the response ourselves to improve
+     * the performance.
+     *
+     * @param  Carbon  $startDate
+     * @param  Carbon  $endDate
+     * @param  array  $conversions
+     * @return array
+     */
+    private function exchangeRateDateRangeResultWithSameCurrency(
+        Carbon $startDate,
+        Carbon $endDate,
+        array $conversions = []
+    ): array {
+        for ($date = clone $startDate; $date->lte($endDate); $date->addDay()) {
+            if ($date->isWeekday()) {
+                $conversions[$date->format('Y-m-d')] = 1.0;
+            }
+        }
+
+        return $conversions;
+    }
+
+    /**
+     * Determine whether if the exchange rate should be
+     * cached after it is fetched from the API.
+     *
+     * @param  bool  $shouldCache
+     * @return $this
+     */
+    public function shouldCache(bool $shouldCache = true): self
+    {
+        $this->shouldCache = $shouldCache;
+
+        return $this;
+    }
+
+    /**
+     * Determine whether if the cached result (if it
+     * exists) should be deleted. This will force
+     * a new exchange rate to be fetched from
+     * the API.
+     *
+     * @param  bool  $bustCache
+     * @return $this
+     */
+    public function shouldBustCache(bool $bustCache = true): self
+    {
+        $this->shouldBustCache = $bustCache;
+
+        return $this;
+    }
+
+    /**
+     * Attempt to fetch an item (more than likely an
+     * exchange rate) from the cache. If it exists,
+     * return it. If it has been specified, bust
+     * the cache.
+     *
+     * @param  string  $cacheKey
+     * @return mixed
+     */
+    private function attemptToResolveFromCache(string $cacheKey)
+    {
+        if ($this->shouldBustCache) {
+            $this->cacheRepository->forget($cacheKey);
+            $this->shouldBustCache = false;
+        } elseif ($cachedValue = $this->cacheRepository->getFromCache($cacheKey)) {
+            return $cachedValue;
+        }
+    }
+}

--- a/src/Drivers/Support/SharedDriverLogicHandler.php
+++ b/src/Drivers/Support/SharedDriverLogicHandler.php
@@ -10,8 +10,14 @@ use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\RequestBuilde
 use AshAllenDesign\LaravelExchangeRates\Exceptions\ExchangeRateException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
+use AshAllenDesign\LaravelExchangeRates\Interfaces\RequestSender;
 use Carbon\Carbon;
 
+/**
+ * Several exchange rates APIs are built to follow a similar structure
+ * to each other. So we can use the same logic for a large majority
+ * of the drivers to reduce duplication of code.
+ */
 class SharedDriverLogicHandler
 {
     /**
@@ -20,7 +26,7 @@ class SharedDriverLogicHandler
      *
      * @var RequestBuilder
      */
-    private $requestBuilder;
+    private RequestSender $requestBuilder;
 
     /**
      * The repository used for accessing the cache.
@@ -45,17 +51,10 @@ class SharedDriverLogicHandler
      */
     private $shouldBustCache = false;
 
-    /**
-     * ExchangeRate constructor.
-     *
-     * @param  RequestBuilder|null  $requestBuilder
-     * @param  CacheRepository|null  $cacheRepository
-     */
-    // TODO Add type hinting for the request builder.
-    public function __construct($requestBuilder = null, CacheRepository $cacheRepository = null)
+    public function __construct(RequestSender $requestBuilder, CacheRepository $cacheRepository)
     {
-        $this->requestBuilder = $requestBuilder ?? new RequestBuilder();
-        $this->cacheRepository = $cacheRepository ?? new CacheRepository();
+        $this->requestBuilder = $requestBuilder;
+        $this->cacheRepository = $cacheRepository;
     }
 
     /**

--- a/src/Drivers/Support/SharedDriverLogicHandler.php
+++ b/src/Drivers/Support/SharedDriverLogicHandler.php
@@ -11,6 +11,7 @@ use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Interfaces\RequestSender;
 use Carbon\Carbon;
+use Illuminate\Http\Client\RequestException;
 
 /**
  * Several exchange rates APIs are built to follow a similar structure
@@ -93,14 +94,15 @@ class SharedDriverLogicHandler
      * string. If $to is an array, the rates
      * will be returned within an array.
      *
-     * @param  string  $from
-     * @param  string|array  $to
-     * @param  Carbon|null  $date
+     * @param string $from
+     * @param string|array $to
+     * @param Carbon|null $date
      * @return float|string|array
      *
-     * @throws InvalidDateException
-     * @throws InvalidCurrencyException
      * @throws ExchangeRateException
+     * @throws InvalidCurrencyException
+     * @throws InvalidDateException
+     * @throws RequestException
      */
     public function exchangeRate(string $from, $to, Carbon $date = null)
     {
@@ -153,7 +155,9 @@ class SharedDriverLogicHandler
      * @param  array  $conversions
      * @return array
      *
-     * @throws Exception
+     * @throws InvalidDateException
+     * @throws InvalidCurrencyException
+     * @throws ExchangeRateException
      */
     public function exchangeRateBetweenDateRange(
         string $from,
@@ -264,7 +268,9 @@ class SharedDriverLogicHandler
      * @param  array  $conversions
      * @return array
      *
-     * @throws Exception
+     * @throws InvalidDateException
+     * @throws InvalidCurrencyException
+     * @throws ExchangeRateException
      */
     public function convertBetweenDateRange(
         int $value,

--- a/src/Drivers/Support/SharedDriverLogicHandler.php
+++ b/src/Drivers/Support/SharedDriverLogicHandler.php
@@ -24,7 +24,7 @@ class SharedDriverLogicHandler
 {
     /**
      * The object used for making requests to the currency conversion API.
-     *
+     */
     private RequestSender $requestBuilder;
 
     /**

--- a/src/Drivers/Support/SharedDriverLogicHandler.php
+++ b/src/Drivers/Support/SharedDriverLogicHandler.php
@@ -17,15 +17,14 @@ use Carbon\Carbon;
  * Several exchange rates APIs are built to follow a similar structure
  * to each other. So we can use the same logic for a large majority
  * of the drivers to reduce duplication of code.
+ *
+ * @interal
  */
 class SharedDriverLogicHandler
 {
     /**
-     * The object used for making requests to the currency
-     * conversion API.
+     * The object used for making requests to the currency conversion API.
      *
-     * @var RequestBuilder
-     */
     private RequestSender $requestBuilder;
 
     /**

--- a/src/Interfaces/RequestSender.php
+++ b/src/Interfaces/RequestSender.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AshAllenDesign\LaravelExchangeRates\Interfaces;
+
+use Illuminate\Http\Client\RequestException;
+
+interface RequestSender
+{
+    /**
+     * Make an API request to the ExchangeRatesAPI.
+     *
+     * @param  string  $path
+     * @param  string[]  $queryParams
+     * @return mixed
+     *
+     * @throws RequestException
+     */
+    public function makeRequest(string $path, array $queryParams = []): mixed;
+}


### PR DESCRIPTION
A lot of the exchange rates APIs available online use the same structures. So I've created a shared handler class that we can use to reduce code duplication. This also makes it easier for us to support other drivers that also follow the same structure.

I'm not sure if I'm 100% happy with the approach I've taken here, so it might end up changing 🙂