### PR TITLE
Remove exception from docblocks

### DIFF
--- a/src/Classes/CacheRepository.php
+++ b/src/Classes/CacheRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\LaravelExchangeRates\Classes;
 
-use AshAllenDesign\LaravelExchangeRates\Exceptions\ExchangeRateException;
 use Carbon\Carbon;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Repository;
@@ -80,8 +79,6 @@ class CacheRepository
      * @param  Carbon  $date
      * @param  Carbon|null  $endDate
      * @return string
-     *
-     * @throws ExchangeRateException
      */
     public function buildCacheKey(string $from, string|array $to, Carbon $date, Carbon $endDate = null): string
     {

--- a/src/Drivers/Support/SharedDriverLogicHandler.php
+++ b/src/Drivers/Support/SharedDriverLogicHandler.php
@@ -6,7 +6,6 @@ namespace AshAllenDesign\LaravelExchangeRates\Drivers\Support;
 
 use AshAllenDesign\LaravelExchangeRates\Classes\CacheRepository;
 use AshAllenDesign\LaravelExchangeRates\Classes\Validation;
-use AshAllenDesign\LaravelExchangeRates\Exceptions\ExchangeRateException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Interfaces\RequestSender;
@@ -91,7 +90,6 @@ class SharedDriverLogicHandler
      * @param  Carbon|null  $date
      * @return float|array<string, float>
      *
-     * @throws ExchangeRateException
      * @throws InvalidCurrencyException
      * @throws InvalidDateException
      * @throws RequestException
@@ -144,7 +142,6 @@ class SharedDriverLogicHandler
      * @param  Carbon  $endDate
      * @return array<string, float>|array<string, array<string, float>>
      *
-     * @throws ExchangeRateException
      * @throws InvalidCurrencyException
      * @throws InvalidDateException
      * @throws RequestException
@@ -227,7 +224,6 @@ class SharedDriverLogicHandler
      *
      * @throws InvalidDateException
      * @throws InvalidCurrencyException
-     * @throws ExchangeRateException
      * @throws RequestException
      * @throws InvalidArgumentException
      */
@@ -256,7 +252,6 @@ class SharedDriverLogicHandler
      * @param  Carbon  $endDate
      * @return array<string, float>|array<string, array<string, float>>
      *
-     * @throws ExchangeRateException
      * @throws InvalidCurrencyException
      * @throws InvalidDateException
      * @throws RequestException

--- a/src/Interfaces/ExchangeRateDriver.php
+++ b/src/Interfaces/ExchangeRateDriver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\LaravelExchangeRates\Interfaces;
 
-use AshAllenDesign\LaravelExchangeRates\Exceptions\ExchangeRateException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use Carbon\Carbon;
@@ -34,7 +33,6 @@ interface ExchangeRateDriver
      * @param  Carbon|null  $date
      * @return float|array<string, float>
      *
-     * @throws ExchangeRateException
      * @throws InvalidCurrencyException
      * @throws InvalidDateException
      * @throws RequestException
@@ -51,7 +49,6 @@ interface ExchangeRateDriver
      * @param  Carbon  $endDate
      * @return array<string, float>|array<string, array<string, float>>
      *
-     * @throws ExchangeRateException
      * @throws InvalidCurrencyException
      * @throws InvalidDateException
      * @throws RequestException
@@ -76,7 +73,6 @@ interface ExchangeRateDriver
      *
      * @throws InvalidDateException
      * @throws InvalidCurrencyException
-     * @throws ExchangeRateException
      * @throws RequestException
      * @throws InvalidArgumentException
      */
@@ -92,7 +88,6 @@ interface ExchangeRateDriver
      * @param  Carbon  $endDate
      * @return array<string, float>|array<string, array<string, float>>
      *
-     * @throws ExchangeRateException
      * @throws InvalidCurrencyException
      * @throws InvalidDateException
      * @throws RequestException


### PR DESCRIPTION
When the `Validation::validateIsStringOrArray` method was removed, it removed all instances of the `ExchangeRateException` from being thrown. But I forgot to update the docblocks accordingly.

I'll leave the exception there because I think it might come in handy for later.