### PR TITLE
Removed "earliest date" validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Removed the `api_url` config option. [#84](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/84)
 - Removed `existsInCache` method from the `src/Classes/CacheRepository.php` file. [#106](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/106)
 - Removed `validateIsStringOrArray` method from the `src/Classes/Validation` file. [#106](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/106)
+- Removed the validation that ensured a date wasn't before the 4th January 1999. 
 
 **v5.2.0 (released 2023-01-11):**
 - Added support for Laravel 10. [#81](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/81)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Removed the `api_url` config option. [#84](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/84)
 - Removed `existsInCache` method from the `src/Classes/CacheRepository.php` file. [#106](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/106)
 - Removed `validateIsStringOrArray` method from the `src/Classes/Validation` file. [#106](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/106)
-- Removed the validation that ensured a date wasn't before the 4th January 1999. 
+- Removed the validation that ensured a date wasn't before the 4th January 1999. [#117](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/117)
 
 **v5.2.0 (released 2023-01-11):**
 - Added support for Laravel 10. [#81](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/81)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -88,6 +88,12 @@ For example, the `exchange-rates-api-io` driver has a `src/Drivers/ExchangeRates
 
 If you're using or extending the `src/Classes/RequestBuilder` class, you'll need to update your code to use the correct driver's request builder instead.
 
+### Removed the "earliest date" validation
+
+Previously, Laravel Exchange Rates only worked with the `exchangeratesapi.io` API. This API only allowed you to retrieve exchange rates for dates after the 4th January 1999. So, the package used to prevent any dates before this from being used and would throw an `AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException` exception if you tried to use a date before this.
+
+As of v6.0.0, Laravel Exchange Rates now supports multiple APIs. Some of these APIs allow you to retrieve exchange rates for dates before the 4th January 1999. So, the package no longer prevents you from using dates before this. Instead, it will let the API handle the validation. If you'd still like to prevent dates before this from being used, you can add your own validation to your application's code.
+
 ## Upgrading from 4.* to 5.0.0
 
 ### Minimum PHP Version

--- a/src/Classes/Validation.php
+++ b/src/Classes/Validation.php
@@ -64,9 +64,7 @@ class Validation
     }
 
     /**
-     * Validate the date that has been passed. We check that the date is in the past but
-     * that it's not before the earliest possible date that the exchange rates support
-     * (4th January 1999).
+     * Validate the date that has been passed is in the past.
      *
      * @param  Carbon  $date
      *
@@ -76,12 +74,6 @@ class Validation
     {
         if (! $date->isPast()) {
             throw new InvalidDateException('The date must be in the past.');
-        }
-
-        $earliestPossibleDate = Carbon::createFromDate(1999, 1, 4)->startOfDay();
-
-        if ($date->isBefore($earliestPossibleDate)) {
-            throw new InvalidDateException('The date cannot be before 4th January 1999.');
         }
     }
 }

--- a/tests/Unit/Drivers/ExchangeRatesApiIo/ExchangeRateTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesApiIo/ExchangeRateTest.php
@@ -200,16 +200,6 @@ final class ExchangeRateTest extends TestCase
     }
 
     /** @test */
-    public function exception_is_thrown_if_the_date_is_before_the_earliest_possible_date(): void
-    {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage('The date cannot be before 4th January 1999.');
-
-        $exchangeRate = new ExchangeRatesApiIoDriver();
-        $exchangeRate->exchangeRate('GBP', 'USD', Carbon::createFromDate(1999, 1, 3));
-    }
-
-    /** @test */
     public function exception_is_thrown_if_the_to_parameter_array_is_invalid(): void
     {
         $this->expectException(InvalidCurrencyException::class);

--- a/tests/Unit/Drivers/ExchangeRatesDataApi/ExchangeRateTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesDataApi/ExchangeRateTest.php
@@ -200,16 +200,6 @@ final class ExchangeRateTest extends TestCase
     }
 
     /** @test */
-    public function exception_is_thrown_if_the_date_is_before_the_earliest_possible_date(): void
-    {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage('The date cannot be before 4th January 1999.');
-
-        $exchangeRate = new ExchangeRatesDataApiDriver();
-        $exchangeRate->exchangeRate('GBP', 'USD', Carbon::createFromDate(1999, 1, 3));
-    }
-
-    /** @test */
     public function exception_is_thrown_if_the_to_parameter_array_is_invalid(): void
     {
         $this->expectException(InvalidCurrencyException::class);


### PR DESCRIPTION
Previously, Laravel Exchange Rates only worked with the `exchangeratesapi.io` API. This API only allowed you to retrieve exchange rates for dates after the 4th January 1999. So, the package used to prevent any dates before this from being used and would throw an `AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException` exception if you tried to use a date before this.

As of v6.0.0, Laravel Exchange Rates now supports multiple APIs. Some of these APIs allow you to retrieve exchange rates for dates before the 4th January 1999. So, the package no longer prevents you from using dates before this. Instead, it will let the API handle the validation.