### PR TITLE
Response abstraction

### DIFF
--- a/src/Drivers/ExchangeRateHost/RequestBuilder.php
+++ b/src/Drivers/ExchangeRateHost/RequestBuilder.php
@@ -2,7 +2,9 @@
 
 namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost;
 
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\Response;
 use AshAllenDesign\LaravelExchangeRates\Interfaces\RequestSender;
+use AshAllenDesign\LaravelExchangeRates\Interfaces\ResponseContract;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 
@@ -15,15 +17,17 @@ class RequestBuilder implements RequestSender
      *
      * @param  string  $path
      * @param  array<string, string>  $queryParams
-     * @return mixed
+     * @return ResponseContract
      *
      * @throws RequestException
      */
-    public function makeRequest(string $path, array $queryParams = []): mixed
+    public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
-        return Http::baseUrl(self::BASE_URL)
+        $rawResponse = Http::baseUrl(self::BASE_URL)
             ->get($path, $queryParams)
             ->throw()
             ->json();
+
+        return new Response($rawResponse);
     }
 }

--- a/src/Drivers/ExchangeRateHost/Response.php
+++ b/src/Drivers/ExchangeRateHost/Response.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost;
+
+use AshAllenDesign\LaravelExchangeRates\Interfaces\ResponseContract;
+
+class Response implements ResponseContract
+{
+    public function __construct(private array $rawResponse)
+    {
+    }
+
+    public function get(string $key): mixed
+    {
+        return $this->rawResponse[$key] ?? collect($this->rawResponse)->flatten()->get($key);
+    }
+
+    public function rates(): array
+    {
+        return $this->get('rates');
+    }
+
+    public function raw(): mixed
+    {
+        return $this->rawResponse;
+    }
+}

--- a/src/Drivers/ExchangeRateHost/Response.php
+++ b/src/Drivers/ExchangeRateHost/Response.php
@@ -12,7 +12,7 @@ class Response implements ResponseContract
 
     public function get(string $key): mixed
     {
-        return $this->rawResponse[$key] ?? collect($this->rawResponse)->flatten()->get($key);
+        return $this->rawResponse[$key];
     }
 
     public function rates(): array

--- a/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
+++ b/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
@@ -3,6 +3,7 @@
 namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo;
 
 use AshAllenDesign\LaravelExchangeRates\Interfaces\RequestSender;
+use AshAllenDesign\LaravelExchangeRates\Interfaces\ResponseContract;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 
@@ -22,18 +23,20 @@ class RequestBuilder implements RequestSender
      *
      * @param  string  $path
      * @param  array<string, string>  $queryParams
-     * @return mixed
+     * @return ResponseContract
      *
      * @throws RequestException
      */
-    public function makeRequest(string $path, array $queryParams = []): mixed
+    public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
-        return Http::baseUrl(self::BASE_URL)
+        $rawResponse = Http::baseUrl(self::BASE_URL)
             ->get(
                 $path,
                 array_merge(['access_key' => $this->apiKey], $queryParams)
             )
             ->throw()
             ->json();
+
+        return new Response($rawResponse);
     }
 }

--- a/src/Drivers/ExchangeRatesApiIo/Response.php
+++ b/src/Drivers/ExchangeRatesApiIo/Response.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo;
+
+use AshAllenDesign\LaravelExchangeRates\Interfaces\ResponseContract;
+
+class Response implements ResponseContract
+{
+    public function __construct(private array $rawResponse)
+    {
+    }
+
+    public function get(string $key): mixed
+    {
+        return $this->rawResponse[$key] ?? collect($this->rawResponse)->flatten()->get($key);
+    }
+
+    public function rates(): array
+    {
+        return $this->get('rates');
+    }
+
+    public function raw(): mixed
+    {
+        return $this->rawResponse;
+    }
+}

--- a/src/Drivers/ExchangeRatesApiIo/Response.php
+++ b/src/Drivers/ExchangeRatesApiIo/Response.php
@@ -12,7 +12,7 @@ class Response implements ResponseContract
 
     public function get(string $key): mixed
     {
-        return $this->rawResponse[$key] ?? collect($this->rawResponse)->flatten()->get($key);
+        return $this->rawResponse[$key];
     }
 
     public function rates(): array

--- a/src/Drivers/ExchangeRatesDataApi/RequestBuilder.php
+++ b/src/Drivers/ExchangeRatesDataApi/RequestBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi;
 
 use AshAllenDesign\LaravelExchangeRates\Interfaces\RequestSender;
+use AshAllenDesign\LaravelExchangeRates\Interfaces\ResponseContract;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 
@@ -24,18 +25,20 @@ class RequestBuilder implements RequestSender
      *
      * @param  string  $path
      * @param  array<string, string>  $queryParams
-     * @return mixed
+     * @return ResponseContract
      *
      * @throws RequestException
      */
-    public function makeRequest(string $path, array $queryParams = []): mixed
+    public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
-        return Http::baseUrl(self::BASE_URL)
+        $rawResponse = Http::baseUrl(self::BASE_URL)
             ->withHeaders([
                 'apiKey' => $this->apiKey,
             ])
             ->get($path, $queryParams)
             ->throw()
             ->json();
+
+        return new Response($rawResponse);
     }
 }

--- a/src/Drivers/ExchangeRatesDataApi/Response.php
+++ b/src/Drivers/ExchangeRatesDataApi/Response.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi;
+
+use AshAllenDesign\LaravelExchangeRates\Interfaces\ResponseContract;
+
+class Response implements ResponseContract
+{
+    public function __construct(private array $rawResponse)
+    {
+    }
+
+    public function get(string $key): mixed
+    {
+        return $this->rawResponse[$key] ?? collect($this->rawResponse)->flatten()->get($key);
+    }
+
+    public function rates(): array
+    {
+        return $this->get('rates');
+    }
+
+    public function raw(): mixed
+    {
+        return $this->rawResponse;
+    }
+}

--- a/src/Drivers/ExchangeRatesDataApi/Response.php
+++ b/src/Drivers/ExchangeRatesDataApi/Response.php
@@ -12,7 +12,7 @@ class Response implements ResponseContract
 
     public function get(string $key): mixed
     {
-        return $this->rawResponse[$key] ?? collect($this->rawResponse)->flatten()->get($key);
+        return $this->rawResponse[$key];
     }
 
     public function rates(): array

--- a/src/Drivers/Support/SharedDriverLogicHandler.php
+++ b/src/Drivers/Support/SharedDriverLogicHandler.php
@@ -66,9 +66,9 @@ class SharedDriverLogicHandler
 
         $response = $this->requestBuilder->makeRequest('/latest', []);
 
-        $currencies = [$response['base']];
+        $currencies = [$response->get('base')];
 
-        foreach ($response['rates'] as $currency => $rate) {
+        foreach ($response->rates() as $currency => $rate) {
             $currencies[] = $currency;
         }
 
@@ -122,7 +122,7 @@ class SharedDriverLogicHandler
             ? '/'.$date->format('Y-m-d')
             : '/latest';
 
-        $response = $this->requestBuilder->makeRequest($url, $queryParams)['rates'];
+        $response = $this->requestBuilder->makeRequest($url, $queryParams)->rates();
 
         $exchangeRate = is_string($to) ? $response[$to] : $response;
 
@@ -199,7 +199,7 @@ class SharedDriverLogicHandler
             'symbols'  => $symbols,
         ]);
 
-        $conversions = $result['rates'];
+        $conversions = $result->rates();
 
         if (is_string($to)) {
             foreach ($conversions as $date => $rate) {

--- a/src/Interfaces/RequestSender.php
+++ b/src/Interfaces/RequestSender.php
@@ -13,9 +13,9 @@ interface RequestSender
      *
      * @param  string  $path
      * @param  string[]  $queryParams
-     * @return mixed
+     * @return ResponseContract
      *
      * @throws RequestException
      */
-    public function makeRequest(string $path, array $queryParams = []): mixed;
+    public function makeRequest(string $path, array $queryParams = []): ResponseContract;
 }

--- a/src/Interfaces/ResponseContract.php
+++ b/src/Interfaces/ResponseContract.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AshAllenDesign\LaravelExchangeRates\Interfaces;
+
+interface ResponseContract
+{
+    public function rates(): array;
+
+    public function raw(): mixed;
+
+    public function get(string $key): mixed;
+}

--- a/tests/Unit/Drivers/ExchangeRateHost/ConvertBetweenDateRangeTest.php
+++ b/tests/Unit/Drivers/ExchangeRateHost/ConvertBetweenDateRangeTest.php
@@ -6,6 +6,7 @@ namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRateHos
 
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\ExchangeRateHostDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\Response;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
@@ -268,9 +269,9 @@ final class ConvertBetweenDateRangeTest extends TestCase
         $exchangeRate->convertBetweenDateRange(100, 'GBP', 'INVALID', now()->subWeek(), now()->subDay());
     }
 
-    private function mockResponseForOneSymbol(): array
+    private function mockResponseForOneSymbol(): Response
     {
-        return [
+        return new Response([
             'rates'    => [
                 '2019-11-08' => [
                     'EUR' => 1.1606583254,
@@ -291,12 +292,12 @@ final class ConvertBetweenDateRangeTest extends TestCase
             'start_date' => '2019-11-03',
             'base'     => 'GBP',
             'end_date'   => '2019-11-10',
-        ];
+        ]);
     }
 
-    private function mockResponseForMultipleSymbols(): array
+    private function mockResponseForMultipleSymbols(): Response
     {
-        return [
+        return new Response([
             'rates'    => [
                 '2019-11-08' => [
                     'EUR' => 1.1606583254,
@@ -322,6 +323,6 @@ final class ConvertBetweenDateRangeTest extends TestCase
             'start_date' => '2019-11-03',
             'base'     => 'GBP',
             'end_date'   => '2019-11-10',
-        ];
+        ]);
     }
 }

--- a/tests/Unit/Drivers/ExchangeRateHost/ConvertTest.php
+++ b/tests/Unit/Drivers/ExchangeRateHost/ConvertTest.php
@@ -6,6 +6,7 @@ namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRateHos
 
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\ExchangeRateHostDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\Response;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
@@ -142,9 +143,9 @@ final class ConvertTest extends TestCase
         $exchangeRate->convert(100, 'GBP', 'INVALID', now()->subMinute());
     }
 
-    private function mockResponseForCurrentDateAndOneSymbol(): array
+    private function mockResponseForCurrentDateAndOneSymbol(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'CAD' => 1.4561,
                 'HKD' => 8.6372,
@@ -181,13 +182,12 @@ final class ConvertTest extends TestCase
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-08',
-        ];
+        ]);
     }
 
-    private function mockResponseForPastDateAndOneSymbol(): array
+    private function mockResponseForPastDateAndOneSymbol(): Response
     {
-        return
-            [
+        return new Response([
                 'rates' => [
                     'CAD' => 1.4969,
                     'HKD' => 8.8843,
@@ -224,12 +224,12 @@ final class ConvertTest extends TestCase
                 ],
                 'base'  => 'EUR',
                 'date'  => '2018-11-09',
-            ];
+            ]);
     }
 
-    private function mockResponseForCurrentDateAndMultipleSymbols(): array
+    private function mockResponseForCurrentDateAndMultipleSymbols(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'CAD' => 1.4561,
                 'USD' => 1.1034,
@@ -237,6 +237,6 @@ final class ConvertTest extends TestCase
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-08',
-        ];
+        ]);
     }
 }

--- a/tests/Unit/Drivers/ExchangeRateHost/CurrenciesTest.php
+++ b/tests/Unit/Drivers/ExchangeRateHost/CurrenciesTest.php
@@ -6,6 +6,7 @@ namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRateHos
 
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\ExchangeRateHostDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\Response;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
@@ -77,9 +78,9 @@ final class CurrenciesTest extends TestCase
         $this->assertNull(Cache::get('laravel_xr_currencies'));
     }
 
-    private function mockResponse(): array
+    private function mockResponse(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'CAD' => 1.4682,
                 'HKD' => 8.7298,
@@ -116,7 +117,7 @@ final class CurrenciesTest extends TestCase
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-01',
-        ];
+        ]);
     }
 
     private function expectedResponse(): array

--- a/tests/Unit/Drivers/ExchangeRateHost/ExchangeRateBetweenDateRangeTest.php
+++ b/tests/Unit/Drivers/ExchangeRateHost/ExchangeRateBetweenDateRangeTest.php
@@ -6,6 +6,7 @@ namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRateHos
 
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\ExchangeRateHostDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\Response;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
@@ -282,9 +283,9 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
         $exchangeRate->exchangeRateBetweenDateRange('GBP', ['USD', 'INVALID'], now()->subWeek(), now()->subDay());
     }
 
-    private function mockResponseForOneSymbol(): array
+    private function mockResponseForOneSymbol(): Response
     {
-        return [
+        return new Response([
             'rates'    => [
                 '2019-11-08' => [
                     'EUR' => 1.1606583254,
@@ -305,12 +306,12 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
             'start_date' => '2019-11-03',
             'base'     => 'GBP',
             'end_date'   => '2019-11-10',
-        ];
+        ]);
     }
 
-    private function mockResponseForMultipleSymbols(): array
+    private function mockResponseForMultipleSymbols(): Response
     {
-        return [
+        return new Response([
             'rates'    => [
                 '2019-11-08' => [
                     'EUR' => 1.1606583254,
@@ -336,6 +337,6 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
             'start_date' => '2019-11-03',
             'base'     => 'GBP',
             'end_date'   => '2019-11-10',
-        ];
+        ]);
     }
 }

--- a/tests/Unit/Drivers/ExchangeRateHost/ExchangeRateTest.php
+++ b/tests/Unit/Drivers/ExchangeRateHost/ExchangeRateTest.php
@@ -6,6 +6,7 @@ namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRateHos
 
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\ExchangeRateHostDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\Response;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
@@ -26,7 +27,7 @@ final class ExchangeRateTest extends TestCase
         $exchangeRate = new ExchangeRateHostDriver($requestBuilderMock);
         $rate = $exchangeRate->exchangeRate('EUR', 'GBP');
         $this->assertEquals('0.86158', $rate);
-        $this->assertEquals('0.86158', Cache::get('laravel_xr_EUR_GBP_'.now()->format('Y-m-d')));
+        $this->assertEquals('0.86158', Cache::get('laravel_xr_EUR_GBP_' . now()->format('Y-m-d')));
     }
 
     /** @test */
@@ -36,14 +37,14 @@ final class ExchangeRateTest extends TestCase
 
         $requestBuilderMock = Mockery::mock(RequestBuilder::class);
         $requestBuilderMock->expects('makeRequest')
-            ->withArgs(['/'.$mockDate->format('Y-m-d'), ['base' => 'EUR', 'symbols' => 'GBP']])
+            ->withArgs(['/' . $mockDate->format('Y-m-d'), ['base' => 'EUR', 'symbols' => 'GBP']])
             ->once()
             ->andReturn($this->mockResponseForPastDateAndOneSymbol());
 
         $exchangeRate = new ExchangeRateHostDriver($requestBuilderMock);
         $rate = $exchangeRate->exchangeRate('EUR', 'GBP', $mockDate);
         $this->assertEquals('0.87053', $rate);
-        $this->assertEquals('0.87053', Cache::get('laravel_xr_EUR_GBP_'.$mockDate->format('Y-m-d')));
+        $this->assertEquals('0.87053', Cache::get('laravel_xr_EUR_GBP_' . $mockDate->format('Y-m-d')));
     }
 
     /** @test */
@@ -51,7 +52,7 @@ final class ExchangeRateTest extends TestCase
     {
         $mockDate = now();
 
-        Cache::forever('laravel_xr_EUR_GBP_'.$mockDate->format('Y-m-d'), 0.123456);
+        Cache::forever('laravel_xr_EUR_GBP_' . $mockDate->format('Y-m-d'), 0.123456);
 
         $requestBuilderMock = Mockery::mock(RequestBuilder::class);
         $requestBuilderMock->expects('makeRequest')->never();
@@ -59,7 +60,7 @@ final class ExchangeRateTest extends TestCase
         $exchangeRate = new ExchangeRateHostDriver($requestBuilderMock);
         $rate = $exchangeRate->exchangeRate('EUR', 'GBP', $mockDate);
         $this->assertEquals('0.123456', $rate);
-        $this->assertEquals('0.123456', Cache::get('laravel_xr_EUR_GBP_'.$mockDate->format('Y-m-d')));
+        $this->assertEquals('0.123456', Cache::get('laravel_xr_EUR_GBP_' . $mockDate->format('Y-m-d')));
     }
 
     /** @test */
@@ -76,7 +77,7 @@ final class ExchangeRateTest extends TestCase
         $this->assertEquals(['CAD' => 1.4561, 'USD' => 1.1034, 'GBP' => 0.86158], $response);
         $this->assertEquals(
             ['CAD' => 1.4561, 'USD' => 1.1034, 'GBP' => 0.86158],
-            Cache::get('laravel_xr_EUR_CAD_GBP_USD_'.now()->format('Y-m-d'))
+            Cache::get('laravel_xr_EUR_CAD_GBP_USD_' . now()->format('Y-m-d'))
         );
     }
 
@@ -87,7 +88,7 @@ final class ExchangeRateTest extends TestCase
 
         $requestBuilderMock = Mockery::mock(RequestBuilder::class);
         $requestBuilderMock->expects('makeRequest')
-            ->withArgs(['/'.$mockDate->format('Y-m-d'), ['base' => 'EUR', 'symbols' => 'GBP,CAD,USD']])
+            ->withArgs(['/' . $mockDate->format('Y-m-d'), ['base' => 'EUR', 'symbols' => 'GBP,CAD,USD']])
             ->once()
             ->andReturn($this->mockResponseForPastDateAndMultipleSymbols());
 
@@ -96,7 +97,7 @@ final class ExchangeRateTest extends TestCase
         $this->assertEquals(['CAD' => 1.4969, 'USD' => 1.1346, 'GBP' => 0.87053], $response);
         $this->assertEquals(
             ['CAD' => 1.4969, 'USD' => 1.1346, 'GBP' => 0.87053],
-            Cache::get('laravel_xr_EUR_CAD_GBP_USD_'.$mockDate->format('Y-m-d'))
+            Cache::get('laravel_xr_EUR_CAD_GBP_USD_' . $mockDate->format('Y-m-d'))
         );
     }
 
@@ -105,9 +106,9 @@ final class ExchangeRateTest extends TestCase
     {
         $mockDate = now();
 
-        Cache::forget('laravel_xr_EUR_CAD_GBP_USD_'.$mockDate->format('Y-m-d'));
+        Cache::forget('laravel_xr_EUR_CAD_GBP_USD_' . $mockDate->format('Y-m-d'));
 
-        Cache::forever('laravel_xr_EUR_CAD_GBP_USD_'.$mockDate->format('Y-m-d'),
+        Cache::forever('laravel_xr_EUR_CAD_GBP_USD_' . $mockDate->format('Y-m-d'),
             ['CAD' => 1.4561, 'USD' => 1.1034, 'GBP' => 0.86158]
         );
 
@@ -119,7 +120,7 @@ final class ExchangeRateTest extends TestCase
         $this->assertEquals(['CAD' => 1.4561, 'USD' => 1.1034, 'GBP' => 0.86158], $rate);
         $this->assertEquals(
             ['CAD' => 1.4561, 'USD' => 1.1034, 'GBP' => 0.86158],
-            Cache::get('laravel_xr_EUR_CAD_GBP_USD_'.$mockDate->format('Y-m-d'))
+            Cache::get('laravel_xr_EUR_CAD_GBP_USD_' . $mockDate->format('Y-m-d'))
         );
     }
 
@@ -128,18 +129,18 @@ final class ExchangeRateTest extends TestCase
     {
         $mockDate = now();
 
-        Cache::forever('laravel_xr_EUR_GBP_'.$mockDate->format('Y-m-d'), '0.123456');
+        Cache::forever('laravel_xr_EUR_GBP_' . $mockDate->format('Y-m-d'), '0.123456');
 
         $requestBuilderMock = Mockery::mock(RequestBuilder::class);
         $requestBuilderMock->expects('makeRequest')
-            ->withArgs(['/'.$mockDate->format('Y-m-d'), ['base' => 'EUR', 'symbols' => 'GBP']])
+            ->withArgs(['/' . $mockDate->format('Y-m-d'), ['base' => 'EUR', 'symbols' => 'GBP']])
             ->once()
             ->andReturn($this->mockResponseForPastDateAndOneSymbol());
 
         $exchangeRate = new ExchangeRateHostDriver($requestBuilderMock);
         $rate = $exchangeRate->shouldBustCache()->exchangeRate('EUR', 'GBP', $mockDate);
         $this->assertEquals('0.87053', $rate);
-        $this->assertEquals('0.87053', Cache::get('laravel_xr_EUR_GBP_'.$mockDate->format('Y-m-d')));
+        $this->assertEquals('0.87053', Cache::get('laravel_xr_EUR_GBP_' . $mockDate->format('Y-m-d')));
     }
 
     /** @test */
@@ -154,7 +155,7 @@ final class ExchangeRateTest extends TestCase
         $exchangeRate = new ExchangeRateHostDriver($requestBuilderMock);
         $rate = $exchangeRate->shouldCache(false)->exchangeRate('EUR', 'GBP');
         $this->assertEquals('0.86158', $rate);
-        $this->assertNull(Cache::get('laravel_xr_EUR_GBP_'.now()->format('Y-m-d')));
+        $this->assertNull(Cache::get('laravel_xr_EUR_GBP_' . now()->format('Y-m-d')));
     }
 
     /** @test */
@@ -208,53 +209,51 @@ final class ExchangeRateTest extends TestCase
         $exchangeRate->exchangeRate('GBP', ['INVALID'], now()->subMinute());
     }
 
-    private function mockResponseForCurrentDateAndOneSymbol(): array
+    private function mockResponseForCurrentDateAndOneSymbol(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'GBP' => 0.86158,
             ],
-            'base'  => 'EUR',
-            'date'  => '2019-11-08',
-        ];
+            'base' => 'EUR',
+            'date' => '2019-11-08',
+        ]);
     }
 
-    private function mockResponseForCurrentDateAndMultipleSymbols(): array
+    private function mockResponseForCurrentDateAndMultipleSymbols(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'CAD' => 1.4561,
                 'USD' => 1.1034,
                 'GBP' => 0.86158,
             ],
-            'base'  => 'EUR',
-            'date'  => '2019-11-08',
-        ];
+            'base' => 'EUR',
+            'date' => '2019-11-08',
+        ]);
     }
 
-    private function mockResponseForPastDateAndOneSymbol(): array
+    private function mockResponseForPastDateAndOneSymbol(): Response
     {
-        return
-            [
-                'rates' => [
-                    'GBP' => 0.87053,
-                ],
-                'base'  => 'EUR',
-                'date'  => '2018-11-09',
-            ];
+        return new Response([
+            'rates' => [
+                'GBP' => 0.87053,
+            ],
+            'base' => 'EUR',
+            'date' => '2018-11-09',
+        ]);
     }
 
-    private function mockResponseForPastDateAndMultipleSymbols(): array
+    private function mockResponseForPastDateAndMultipleSymbols(): Response
     {
-        return
-            [
-                'rates' => [
-                    'CAD' => 1.4969,
-                    'USD' => 1.1346,
-                    'GBP' => 0.87053,
-                ],
-                'base'  => 'EUR',
-                'date'  => '2018-11-09',
-            ];
+        return new Response([
+            'rates' => [
+                'CAD' => 1.4969,
+                'USD' => 1.1346,
+                'GBP' => 0.87053,
+            ],
+            'base' => 'EUR',
+            'date' => '2018-11-09',
+        ]);
     }
 }

--- a/tests/Unit/Drivers/ExchangeRatesApiIo/ConvertBetweenDateRangeTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesApiIo/ConvertBetweenDateRangeTest.php
@@ -6,6 +6,7 @@ namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesAp
 
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\Response;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
@@ -268,9 +269,9 @@ final class ConvertBetweenDateRangeTest extends TestCase
         $exchangeRate->convertBetweenDateRange(100, 'GBP', 'INVALID', now()->subWeek(), now()->subDay());
     }
 
-    private function mockResponseForOneSymbol(): array
+    private function mockResponseForOneSymbol(): Response
     {
-        return [
+        return new Response([
             'rates'    => [
                 '2019-11-08' => [
                     'EUR' => 1.1606583254,
@@ -291,12 +292,12 @@ final class ConvertBetweenDateRangeTest extends TestCase
             'start_date' => '2019-11-03',
             'base'     => 'GBP',
             'end_date'   => '2019-11-10',
-        ];
+        ]);
     }
 
-    private function mockResponseForMultipleSymbols(): array
+    private function mockResponseForMultipleSymbols(): Response
     {
-        return [
+        return new Response([
             'rates'    => [
                 '2019-11-08' => [
                     'EUR' => 1.1606583254,
@@ -322,6 +323,6 @@ final class ConvertBetweenDateRangeTest extends TestCase
             'start_date' => '2019-11-03',
             'base'     => 'GBP',
             'end_date'   => '2019-11-10',
-        ];
+        ]);
     }
 }

--- a/tests/Unit/Drivers/ExchangeRatesApiIo/ConvertTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesApiIo/ConvertTest.php
@@ -6,6 +6,7 @@ namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesAp
 
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\Response;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
@@ -142,9 +143,9 @@ final class ConvertTest extends TestCase
         $exchangeRate->convert(100, 'GBP', 'INVALID', now()->subMinute());
     }
 
-    private function mockResponseForCurrentDateAndOneSymbol(): array
+    private function mockResponseForCurrentDateAndOneSymbol(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'CAD' => 1.4561,
                 'HKD' => 8.6372,
@@ -181,13 +182,12 @@ final class ConvertTest extends TestCase
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-08',
-        ];
+        ]);
     }
 
-    private function mockResponseForPastDateAndOneSymbol(): array
+    private function mockResponseForPastDateAndOneSymbol(): Response
     {
-        return
-            [
+        return new Response([
                 'rates' => [
                     'CAD' => 1.4969,
                     'HKD' => 8.8843,
@@ -224,12 +224,12 @@ final class ConvertTest extends TestCase
                 ],
                 'base'  => 'EUR',
                 'date'  => '2018-11-09',
-            ];
+            ]);
     }
 
-    private function mockResponseForCurrentDateAndMultipleSymbols(): array
+    private function mockResponseForCurrentDateAndMultipleSymbols(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'CAD' => 1.4561,
                 'USD' => 1.1034,
@@ -237,6 +237,6 @@ final class ConvertTest extends TestCase
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-08',
-        ];
+        ]);
     }
 }

--- a/tests/Unit/Drivers/ExchangeRatesApiIo/CurrenciesTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesApiIo/CurrenciesTest.php
@@ -6,6 +6,7 @@ namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesAp
 
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\Response;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
@@ -77,9 +78,9 @@ final class CurrenciesTest extends TestCase
         $this->assertNull(Cache::get('laravel_xr_currencies'));
     }
 
-    private function mockResponse(): array
+    private function mockResponse(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'CAD' => 1.4682,
                 'HKD' => 8.7298,
@@ -116,7 +117,7 @@ final class CurrenciesTest extends TestCase
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-01',
-        ];
+        ]);
     }
 
     private function expectedResponse(): array

--- a/tests/Unit/Drivers/ExchangeRatesApiIo/ExchangeRateBetweenDateRangeTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesApiIo/ExchangeRateBetweenDateRangeTest.php
@@ -6,6 +6,7 @@ namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesAp
 
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\Response;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
@@ -282,9 +283,9 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
         $exchangeRate->exchangeRateBetweenDateRange('GBP', ['USD', 'INVALID'], now()->subWeek(), now()->subDay());
     }
 
-    private function mockResponseForOneSymbol(): array
+    private function mockResponseForOneSymbol(): Response
     {
-        return [
+        return new Response([
             'rates'    => [
                 '2019-11-08' => [
                     'EUR' => 1.1606583254,
@@ -305,12 +306,12 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
             'start_date' => '2019-11-03',
             'base'     => 'GBP',
             'end_date'   => '2019-11-10',
-        ];
+        ]);
     }
 
-    private function mockResponseForMultipleSymbols(): array
+    private function mockResponseForMultipleSymbols(): Response
     {
-        return [
+        return new Response([
             'rates'    => [
                 '2019-11-08' => [
                     'EUR' => 1.1606583254,
@@ -336,6 +337,6 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
             'start_date' => '2019-11-03',
             'base'     => 'GBP',
             'end_date'   => '2019-11-10',
-        ];
+        ]);
     }
 }

--- a/tests/Unit/Drivers/ExchangeRatesApiIo/ExchangeRateTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesApiIo/ExchangeRateTest.php
@@ -6,6 +6,7 @@ namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesAp
 
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\Response;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
@@ -219,20 +220,20 @@ final class ExchangeRateTest extends TestCase
         $exchangeRate->exchangeRate('GBP', ['INVALID'], now()->subMinute());
     }
 
-    private function mockResponseForCurrentDateAndOneSymbol(): array
+    private function mockResponseForCurrentDateAndOneSymbol(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'GBP' => 0.86158,
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-08',
-        ];
+        ]);
     }
 
-    private function mockResponseForCurrentDateAndMultipleSymbols(): array
+    private function mockResponseForCurrentDateAndMultipleSymbols(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'CAD' => 1.4561,
                 'USD' => 1.1034,
@@ -240,25 +241,23 @@ final class ExchangeRateTest extends TestCase
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-08',
-        ];
+        ]);
     }
 
-    private function mockResponseForPastDateAndOneSymbol(): array
+    private function mockResponseForPastDateAndOneSymbol(): Response
     {
-        return
-            [
+        return new Response([
                 'rates' => [
                     'GBP' => 0.87053,
                 ],
                 'base'  => 'EUR',
                 'date'  => '2018-11-09',
-            ];
+            ]);
     }
 
-    private function mockResponseForPastDateAndMultipleSymbols(): array
+    private function mockResponseForPastDateAndMultipleSymbols(): Response
     {
-        return
-            [
+        return new Response([
                 'rates' => [
                     'CAD' => 1.4969,
                     'USD' => 1.1346,
@@ -266,6 +265,6 @@ final class ExchangeRateTest extends TestCase
                 ],
                 'base'  => 'EUR',
                 'date'  => '2018-11-09',
-            ];
+            ]);
     }
 }

--- a/tests/Unit/Drivers/ExchangeRatesDataApi/ConvertBetweenDateRangeTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesDataApi/ConvertBetweenDateRangeTest.php
@@ -6,6 +6,7 @@ namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesDa
 
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\ExchangeRatesDataApiDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\Response;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
@@ -268,9 +269,9 @@ final class ConvertBetweenDateRangeTest extends TestCase
         $exchangeRate->convertBetweenDateRange(100, 'GBP', 'INVALID', now()->subWeek(), now()->subDay());
     }
 
-    private function mockResponseForOneSymbol(): array
+    private function mockResponseForOneSymbol(): Response
     {
-        return [
+        return new Response([
             'rates'    => [
                 '2019-11-08' => [
                     'EUR' => 1.1606583254,
@@ -291,12 +292,12 @@ final class ConvertBetweenDateRangeTest extends TestCase
             'start_date' => '2019-11-03',
             'base'     => 'GBP',
             'end_date'   => '2019-11-10',
-        ];
+        ]);
     }
 
-    private function mockResponseForMultipleSymbols(): array
+    private function mockResponseForMultipleSymbols(): Response
     {
-        return [
+        return new Response([
             'rates'    => [
                 '2019-11-08' => [
                     'EUR' => 1.1606583254,
@@ -322,6 +323,6 @@ final class ConvertBetweenDateRangeTest extends TestCase
             'start_date' => '2019-11-03',
             'base'     => 'GBP',
             'end_date'   => '2019-11-10',
-        ];
+        ]);
     }
 }

--- a/tests/Unit/Drivers/ExchangeRatesDataApi/ConvertTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesDataApi/ConvertTest.php
@@ -11,6 +11,8 @@ use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\Response;
+
 
 final class ConvertTest extends TestCase
 {
@@ -142,9 +144,9 @@ final class ConvertTest extends TestCase
         $exchangeRate->convert(100, 'GBP', 'INVALID', now()->subMinute());
     }
 
-    private function mockResponseForCurrentDateAndOneSymbol(): array
+    private function mockResponseForCurrentDateAndOneSymbol(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'CAD' => 1.4561,
                 'HKD' => 8.6372,
@@ -181,13 +183,13 @@ final class ConvertTest extends TestCase
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-08',
-        ];
+        ]);
     }
 
-    private function mockResponseForPastDateAndOneSymbol(): array
+    private function mockResponseForPastDateAndOneSymbol(): Response
     {
         return
-            [
+            new Response([
                 'rates' => [
                     'CAD' => 1.4969,
                     'HKD' => 8.8843,
@@ -224,12 +226,12 @@ final class ConvertTest extends TestCase
                 ],
                 'base'  => 'EUR',
                 'date'  => '2018-11-09',
-            ];
+            ]);
     }
 
-    private function mockResponseForCurrentDateAndMultipleSymbols(): array
+    private function mockResponseForCurrentDateAndMultipleSymbols(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'CAD' => 1.4561,
                 'USD' => 1.1034,
@@ -237,6 +239,6 @@ final class ConvertTest extends TestCase
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-08',
-        ];
+        ]);
     }
 }

--- a/tests/Unit/Drivers/ExchangeRatesDataApi/CurrenciesTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesDataApi/CurrenciesTest.php
@@ -9,6 +9,8 @@ use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\RequestBuil
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\Response;
+
 
 final class CurrenciesTest extends TestCase
 {
@@ -77,9 +79,9 @@ final class CurrenciesTest extends TestCase
         $this->assertNull(Cache::get('laravel_xr_currencies'));
     }
 
-    private function mockResponse(): array
+    private function mockResponse(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'CAD' => 1.4682,
                 'HKD' => 8.7298,
@@ -116,7 +118,7 @@ final class CurrenciesTest extends TestCase
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-01',
-        ];
+        ]);
     }
 
     private function expectedResponse(): array

--- a/tests/Unit/Drivers/ExchangeRatesDataApi/ExchangeRateBetweenDateRangeTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesDataApi/ExchangeRateBetweenDateRangeTest.php
@@ -12,6 +12,8 @@ use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\Response;
+
 
 final class ExchangeRateBetweenDateRangeTest extends TestCase
 {
@@ -282,9 +284,9 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
         $exchangeRate->exchangeRateBetweenDateRange('GBP', ['USD', 'INVALID'], now()->subWeek(), now()->subDay());
     }
 
-    private function mockResponseForOneSymbol(): array
+    private function mockResponseForOneSymbol(): Response
     {
-        return [
+        return new Response([
             'rates'    => [
                 '2019-11-08' => [
                     'EUR' => 1.1606583254,
@@ -305,12 +307,12 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
             'start_date' => '2019-11-03',
             'base'     => 'GBP',
             'end_date'   => '2019-11-10',
-        ];
+        ]);
     }
 
-    private function mockResponseForMultipleSymbols(): array
+    private function mockResponseForMultipleSymbols(): Response
     {
-        return [
+        return new Response([
             'rates'    => [
                 '2019-11-08' => [
                     'EUR' => 1.1606583254,
@@ -336,6 +338,6 @@ final class ExchangeRateBetweenDateRangeTest extends TestCase
             'start_date' => '2019-11-03',
             'base'     => 'GBP',
             'end_date'   => '2019-11-10',
-        ];
+        ]);
     }
 }

--- a/tests/Unit/Drivers/ExchangeRatesDataApi/ExchangeRateTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesDataApi/ExchangeRateTest.php
@@ -6,6 +6,7 @@ namespace AshAllenDesign\LaravelExchangeRates\Tests\Unit\Drivers\ExchangeRatesDa
 
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\ExchangeRatesDataApiDriver;
 use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\RequestBuilder;
+use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\Response;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidCurrencyException;
 use AshAllenDesign\LaravelExchangeRates\Exceptions\InvalidDateException;
 use AshAllenDesign\LaravelExchangeRates\Tests\Unit\TestCase;
@@ -219,20 +220,20 @@ final class ExchangeRateTest extends TestCase
         $exchangeRate->exchangeRate('GBP', ['INVALID'], now()->subMinute());
     }
 
-    private function mockResponseForCurrentDateAndOneSymbol(): array
+    private function mockResponseForCurrentDateAndOneSymbol(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'GBP' => 0.86158,
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-08',
-        ];
+        ]);
     }
 
-    private function mockResponseForCurrentDateAndMultipleSymbols(): array
+    private function mockResponseForCurrentDateAndMultipleSymbols(): Response
     {
-        return [
+        return new Response([
             'rates' => [
                 'CAD' => 1.4561,
                 'USD' => 1.1034,
@@ -240,25 +241,24 @@ final class ExchangeRateTest extends TestCase
             ],
             'base'  => 'EUR',
             'date'  => '2019-11-08',
-        ];
+        ]);
     }
 
-    private function mockResponseForPastDateAndOneSymbol(): array
+    private function mockResponseForPastDateAndOneSymbol(): Response
     {
-        return
+        return new Response(
             [
                 'rates' => [
                     'GBP' => 0.87053,
                 ],
                 'base'  => 'EUR',
                 'date'  => '2018-11-09',
-            ];
+            ]);
     }
 
-    private function mockResponseForPastDateAndMultipleSymbols(): array
+    private function mockResponseForPastDateAndMultipleSymbols(): Response
     {
-        return
-            [
+        return new Response([
                 'rates' => [
                     'CAD' => 1.4969,
                     'USD' => 1.1346,
@@ -266,6 +266,6 @@ final class ExchangeRateTest extends TestCase
                 ],
                 'base'  => 'EUR',
                 'date'  => '2018-11-09',
-            ];
+            ]);
     }
 }


### PR DESCRIPTION
Added `AshAllenDesign\LaravelExchangeRates\Interfaces\ResponseContract` interface that represent an exchange response API.

By implementing this the `AshAllenDesign\LaravelExchangeRates\Drivers\Support\SharedDriverLogicHandler` doesn't need to know about internal responses specifications (the keys of the response array, the shape of the body, etc), and request the rates from the object that implements ResponseContract.