### PR TITLE
Fixed exception in SharedDriverLogicHandler::exchangeRate()

### DIFF
--- a/src/Drivers/Support/SharedDriverLogicHandler.php
+++ b/src/Drivers/Support/SharedDriverLogicHandler.php
@@ -112,7 +112,7 @@ class SharedDriverLogicHandler
         $cacheKey = $this->cacheRepository->buildCacheKey($from, $to, $date ?? Carbon::now());
 
         if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {
-            return $cachedExchangeRate;
+            return (float)$cachedExchangeRate;
         }
 
         $symbols = is_string($to) ? $to : implode(',', $to);

--- a/src/Drivers/Support/SharedDriverLogicHandler.php
+++ b/src/Drivers/Support/SharedDriverLogicHandler.php
@@ -112,7 +112,13 @@ class SharedDriverLogicHandler
         $cacheKey = $this->cacheRepository->buildCacheKey($from, $to, $date ?? Carbon::now());
 
         if ($cachedExchangeRate = $this->attemptToResolveFromCache($cacheKey)) {
-            return (float)$cachedExchangeRate;
+            // If the exchange rate has been retrieved from the cache as a
+            // string (e.g. "1.23"), then cast it to a float (e.g. 1.23).
+            // If we have retrieved the rates for many currencies, it
+            // will be an array of floats, so just return it.
+            return is_string($cachedExchangeRate)
+                ? (float) $cachedExchangeRate
+                : $cachedExchangeRate;
         }
 
         $symbols = is_string($to) ? $to : implode(',', $to);


### PR DESCRIPTION
Hi!

I'm getting "Return value must be of type array|float, string returned" from SharedDriverLogicHandler::exchangeRate()

This is the fix for this problem.