### PR TITLE
Fix bug that was using the incorrect response class

### DIFF
--- a/src/Drivers/ExchangeRateHost/RequestBuilder.php
+++ b/src/Drivers/ExchangeRateHost/RequestBuilder.php
@@ -2,7 +2,6 @@
 
 namespace AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost;
 
-use AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\Response;
 use AshAllenDesign\LaravelExchangeRates\Interfaces\RequestSender;
 use AshAllenDesign\LaravelExchangeRates\Interfaces\ResponseContract;
 use Illuminate\Http\Client\RequestException;

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -19,7 +19,7 @@ abstract class TestCase extends OrchestraTestCase
     /**
      * Load package service provider.
      *
-     * @param $app
+     * @param  $app
      * @return array
      */
     protected function getPackageProviders($app)


### PR DESCRIPTION
It appears that the `ExchangeRateHost` builder class was incorrectly using the `Response` class that was intended for the `ExchangeRatesApiIo` driver. This PR fixes this so it uses the correct `Response` class.