### PR TITLE
Add config option to disable SSL, to support free tiers of exchangeratesapi.io and exchangerate.host

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 - [Changelog](#changelog)
 - [Upgrading](#upgrading)
 - [License](#license)
-    
+
 ## Overview
 
 A simple Laravel package used for interacting with exchange rates APIs. Laravel Exchange Rates allows you to get the latest or historical exchange rates and convert monetary values between different currencies.
@@ -74,9 +74,9 @@ Laravel Exchange Rates currently supports the following APIs:
 
 ## Configuration
 
-### Publish the Config and Migrations
+### Publish the Config File
 
-You can publish the package's config file and database migrations (so that you can make changes to them) by using the following command:
+You can publish the package's config file using the following command:
 ```bash
 php artisan vendor:publish --provider="AshAllenDesign\LaravelExchangeRates\Providers\ExchangeRatesProvider"
 ```
@@ -86,6 +86,8 @@ If you're using an API that requires an API key, you can put it in your `.env`:
 ``` dotenv
 EXCHANGE_RATES_API_KEY={Your-API-Key-Here}
 ```
+
+If you're using the free tier of `https://exchangeratesapi.io` or `https://exchangerate.host`, you should set the `ssl` config option in `config/laravel-exchange-rates.php` to `false`, as the free tiers of those APIs don't allow SSL requests.
 
 ## Usage
 

--- a/config/laravel-exchange-rates.php
+++ b/config/laravel-exchange-rates.php
@@ -24,4 +24,15 @@ return [
     */
     'api_key' => env('EXCHANGE_RATES_API_KEY'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | SSL Endpoints
+    |--------------------------------------------------------------------------
+    |
+    | Define if the API should be accessed via HTTPS or HTTP. The free tiers of
+    | exchangeratesapi.io and exchangerate.host only allow API access via HTTP.
+    |
+    */
+    'ssl' => true,
+
 ];

--- a/src/Drivers/ExchangeRateHost/RequestBuilder.php
+++ b/src/Drivers/ExchangeRateHost/RequestBuilder.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Http;
 
 class RequestBuilder implements RequestSender
 {
-    private const BASE_URL = 'https://api.exchangerate.host/';
+    private const BASE_URL = 'api.exchangerate.host/';
 
     /**
      * Make an API request to the ExchangeRatesAPI.
@@ -22,7 +22,8 @@ class RequestBuilder implements RequestSender
      */
     public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
-        $rawResponse = Http::baseUrl(self::BASE_URL)
+        $protocol = config('laravel-exchange-rates.ssl') ? 'https://' : 'http://';
+        $rawResponse = Http::baseUrl($protocol . self::BASE_URL)
             ->get($path, $queryParams)
             ->throw()
             ->json();

--- a/src/Drivers/ExchangeRateHost/RequestBuilder.php
+++ b/src/Drivers/ExchangeRateHost/RequestBuilder.php
@@ -23,6 +23,7 @@ class RequestBuilder implements RequestSender
     public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
         $protocol = config('laravel-exchange-rates.ssl') ? 'https://' : 'http://';
+
         $rawResponse = Http::baseUrl($protocol.self::BASE_URL)
             ->get($path, $queryParams)
             ->throw()

--- a/src/Drivers/ExchangeRateHost/RequestBuilder.php
+++ b/src/Drivers/ExchangeRateHost/RequestBuilder.php
@@ -23,7 +23,7 @@ class RequestBuilder implements RequestSender
     public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
         $protocol = config('laravel-exchange-rates.ssl') ? 'https://' : 'http://';
-        $rawResponse = Http::baseUrl($protocol . self::BASE_URL)
+        $rawResponse = Http::baseUrl($protocol.self::BASE_URL)
             ->get($path, $queryParams)
             ->throw()
             ->json();

--- a/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
+++ b/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Http;
 
 class RequestBuilder implements RequestSender
 {
-    private const BASE_URL = 'https://api.exchangeratesapi.io/v1/';
+    private const BASE_URL = 'api.exchangeratesapi.io/v1/';
 
     private string $apiKey;
 
@@ -29,7 +29,8 @@ class RequestBuilder implements RequestSender
      */
     public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
-        $rawResponse = Http::baseUrl(self::BASE_URL)
+        $protocol = config('laravel-exchange-rates.ssl') ? 'https://' : 'http://';
+        $rawResponse = Http::baseUrl($protocol . self::BASE_URL)
             ->get(
                 $path,
                 array_merge(['access_key' => $this->apiKey], $queryParams)

--- a/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
+++ b/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
@@ -30,7 +30,7 @@ class RequestBuilder implements RequestSender
     public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
         $protocol = config('laravel-exchange-rates.ssl') ? 'https://' : 'http://';
-        $rawResponse = Http::baseUrl($protocol . self::BASE_URL)
+        $rawResponse = Http::baseUrl($protocol.self::BASE_URL)
             ->get(
                 $path,
                 array_merge(['access_key' => $this->apiKey], $queryParams)

--- a/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
+++ b/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
@@ -30,6 +30,7 @@ class RequestBuilder implements RequestSender
     public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
         $protocol = config('laravel-exchange-rates.ssl') ? 'https://' : 'http://';
+
         $rawResponse = Http::baseUrl($protocol.self::BASE_URL)
             ->get(
                 $path,

--- a/src/Drivers/ExchangeRatesDataApi/RequestBuilder.php
+++ b/src/Drivers/ExchangeRatesDataApi/RequestBuilder.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Http;
 
 class RequestBuilder implements RequestSender
 {
-    private const BASE_URL = 'https://api.apilayer.com/exchangerates_data/';
+    private const BASE_URL = 'api.apilayer.com/exchangerates_data/';
 
     private string $apiKey;
 
@@ -31,7 +31,9 @@ class RequestBuilder implements RequestSender
      */
     public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
-        $rawResponse = Http::baseUrl(self::BASE_URL)
+        $protocol = config('laravel-exchange-rates.ssl') ? 'https://' : 'http://';
+
+        $rawResponse = Http::baseUrl($protocol.self::BASE_URL)
             ->withHeaders([
                 'apiKey' => $this->apiKey,
             ])

--- a/tests/Unit/Drivers/ExchangeRateHost/RequestBuilderTest.php
+++ b/tests/Unit/Drivers/ExchangeRateHost/RequestBuilderTest.php
@@ -39,6 +39,27 @@ final class RequestBuilderTest extends TestCase
     }
 
     /** @test */
+    public function request_protocol_respects_ssl_config_option(): void
+    {
+        config(['laravel-exchange-rates.ssl' => false]);
+
+        $noSslUrl = 'http://api.exchangerate.host/latest?base=USD';
+
+        Http::fake([
+            $noSslUrl => Http::response(['RESPONSE']),
+            '*' => Http::response('SHOULD NOT HIT THIS!', 500),
+        ]);
+
+        $requestBuilder = new RequestBuilder();
+        $requestBuilder->makeRequest('latest', ['base' => 'USD']);
+
+        Http::assertSent(static function (Request $request) use ($noSslUrl): bool {
+            return $request->method() === 'GET'
+                && $request->url() === $noSslUrl;
+        });
+    }
+
+    /** @test */
     public function exception_is_thrown_if_the_request_fails(): void
     {
         $this->expectException(RequestException::class);

--- a/tests/Unit/Drivers/ExchangeRatesDataApi/RequestBuilderTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesDataApi/RequestBuilderTest.php
@@ -40,6 +40,27 @@ final class RequestBuilderTest extends TestCase
     }
 
     /** @test */
+    public function request_protocol_ignores_ssl_config_option(): void
+    {
+        config(['laravel-exchange-rates.ssl' => false]);
+
+        $url = 'https://api.apilayer.com/exchangerates_data/latest?base=USD';
+
+        Http::fake([
+            $url => Http::response(['RESPONSE']),
+            '*' => Http::response('SHOULD NOT HIT THIS!', 500),
+        ]);
+
+        $requestBuilder = new RequestBuilder();
+        $requestBuilder->makeRequest('latest', ['base' => 'USD']);
+
+        Http::assertSent(static function (Request $request) use ($url): bool {
+            return $request->method() === 'GET'
+                && $request->url() === $url;
+        });
+    }
+
+    /** @test */
     public function exception_is_thrown_if_the_request_fails(): void
     {
         $this->expectException(RequestException::class);

--- a/tests/Unit/Drivers/ExchangeRatesDataApi/RequestBuilderTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesDataApi/RequestBuilderTest.php
@@ -40,11 +40,11 @@ final class RequestBuilderTest extends TestCase
     }
 
     /** @test */
-    public function request_protocol_ignores_ssl_config_option(): void
+    public function request_protocol_respects_ssl_config_option(): void
     {
         config(['laravel-exchange-rates.ssl' => false]);
 
-        $url = 'https://api.apilayer.com/exchangerates_data/latest?base=USD';
+        $url = 'http://api.apilayer.com/exchangerates_data/latest?base=USD';
 
         Http::fake([
             $url => Http::response(['RESPONSE']),


### PR DESCRIPTION
I was running into issues making requests to https://exchangeratesapi.io and https://exchangerate.host on their free tiers, because (per their documentation) they don't support requests on the free tier over SSL. This PR adds an option to disable SSL in the config file, which makes free-tier requests work with those providers.

(I also removed the stuff about migrations from the README, because I don't think there are any migration files associated with this package. Let me know if I'm missing something here.)