### PR TITLE
Renamed `ssl` config option to `https`

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you're using an API that requires an API key, you can put it in your `.env`:
 EXCHANGE_RATES_API_KEY={Your-API-Key-Here}
 ```
 
-If you're using the free tier of `https://exchangeratesapi.io` or `https://exchangerate.host`, you should set the `ssl` config option in `config/laravel-exchange-rates.php` to `false`, as the free tiers of those APIs don't allow SSL requests.
+If you're using the free tier of `https://exchangeratesapi.io` or `https://exchangerate.host`, you should set the `https` config option in `config/laravel-exchange-rates.php` to `false`, as the free tiers of those APIs don't allow HTTPS requests.
 
 ## Usage
 

--- a/config/laravel-exchange-rates.php
+++ b/config/laravel-exchange-rates.php
@@ -26,13 +26,13 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | SSL Endpoints
+    | Use HTTPS
     |--------------------------------------------------------------------------
     |
     | Define if the API should be accessed via HTTPS or HTTP. The free tiers of
     | exchangeratesapi.io and exchangerate.host only allow API access via HTTP.
     |
     */
-    'ssl' => true,
+    'https' => true,
 
 ];

--- a/src/Drivers/ExchangeRateHost/RequestBuilder.php
+++ b/src/Drivers/ExchangeRateHost/RequestBuilder.php
@@ -22,7 +22,7 @@ class RequestBuilder implements RequestSender
      */
     public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
-        $protocol = config('laravel-exchange-rates.ssl') ? 'https://' : 'http://';
+        $protocol = config('laravel-exchange-rates.https') ? 'https://' : 'http://';
 
         $rawResponse = Http::baseUrl($protocol.self::BASE_URL)
             ->get($path, $queryParams)

--- a/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
+++ b/src/Drivers/ExchangeRatesApiIo/RequestBuilder.php
@@ -29,7 +29,7 @@ class RequestBuilder implements RequestSender
      */
     public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
-        $protocol = config('laravel-exchange-rates.ssl') ? 'https://' : 'http://';
+        $protocol = config('laravel-exchange-rates.https') ? 'https://' : 'http://';
 
         $rawResponse = Http::baseUrl($protocol.self::BASE_URL)
             ->get(

--- a/src/Drivers/ExchangeRatesDataApi/RequestBuilder.php
+++ b/src/Drivers/ExchangeRatesDataApi/RequestBuilder.php
@@ -31,7 +31,7 @@ class RequestBuilder implements RequestSender
      */
     public function makeRequest(string $path, array $queryParams = []): ResponseContract
     {
-        $protocol = config('laravel-exchange-rates.ssl') ? 'https://' : 'http://';
+        $protocol = config('laravel-exchange-rates.https') ? 'https://' : 'http://';
 
         $rawResponse = Http::baseUrl($protocol.self::BASE_URL)
             ->withHeaders([

--- a/tests/Unit/Drivers/ExchangeRateHost/RequestBuilderTest.php
+++ b/tests/Unit/Drivers/ExchangeRateHost/RequestBuilderTest.php
@@ -39,23 +39,23 @@ final class RequestBuilderTest extends TestCase
     }
 
     /** @test */
-    public function request_protocol_respects_ssl_config_option(): void
+    public function request_protocol_respects_https_config_option(): void
     {
-        config(['laravel-exchange-rates.ssl' => false]);
+        config(['laravel-exchange-rates.https' => false]);
 
-        $noSslUrl = 'http://api.exchangerate.host/latest?base=USD';
+        $noHttpsUrl = 'http://api.exchangerate.host/latest?base=USD';
 
         Http::fake([
-            $noSslUrl => Http::response(['RESPONSE']),
+            $noHttpsUrl => Http::response(['RESPONSE']),
             '*' => Http::response('SHOULD NOT HIT THIS!', 500),
         ]);
 
         $requestBuilder = new RequestBuilder();
         $requestBuilder->makeRequest('latest', ['base' => 'USD']);
 
-        Http::assertSent(static function (Request $request) use ($noSslUrl): bool {
+        Http::assertSent(static function (Request $request) use ($noHttpsUrl): bool {
             return $request->method() === 'GET'
-                && $request->url() === $noSslUrl;
+                && $request->url() === $noHttpsUrl;
         });
     }
 

--- a/tests/Unit/Drivers/ExchangeRatesApiIo/RequestBuilderTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesApiIo/RequestBuilderTest.php
@@ -39,23 +39,23 @@ final class RequestBuilderTest extends TestCase
     }
 
     /** @test */
-    public function request_protocol_respects_ssl_config_option(): void
+    public function request_protocol_respects_https_config_option(): void
     {
-        config(['laravel-exchange-rates.ssl' => false]);
+        config(['laravel-exchange-rates.https' => false]);
 
-        $noSslUrl = 'http://api.exchangeratesapi.io/v1/latest?access_key=API-KEY&base=USD';
+        $noHttpsUrl = 'http://api.exchangeratesapi.io/v1/latest?access_key=API-KEY&base=USD';
 
         Http::fake([
-            $noSslUrl => Http::response(['RESPONSE']),
+            $noHttpsUrl => Http::response(['RESPONSE']),
             '*' => Http::response('SHOULD NOT HIT THIS!', 500),
         ]);
 
         $requestBuilder = new RequestBuilder();
         $requestBuilder->makeRequest('latest', ['base' => 'USD']);
 
-        Http::assertSent(static function (Request $request) use ($noSslUrl): bool {
+        Http::assertSent(static function (Request $request) use ($noHttpsUrl): bool {
             return $request->method() === 'GET'
-                && $request->url() === $noSslUrl;
+                && $request->url() === $noHttpsUrl;
         });
     }
 

--- a/tests/Unit/Drivers/ExchangeRatesDataApi/RequestBuilderTest.php
+++ b/tests/Unit/Drivers/ExchangeRatesDataApi/RequestBuilderTest.php
@@ -40,9 +40,9 @@ final class RequestBuilderTest extends TestCase
     }
 
     /** @test */
-    public function request_protocol_respects_ssl_config_option(): void
+    public function request_protocol_respects_https_config_option(): void
     {
-        config(['laravel-exchange-rates.ssl' => false]);
+        config(['laravel-exchange-rates.https' => false]);
 
         $url = 'http://api.apilayer.com/exchangerates_data/latest?base=USD';
 


### PR DESCRIPTION
This is just a quick PR that renames the newly added `ssl` config option to `https`. This is purely down to personal preference and I just feel like I prefer the sound of `https` more 🙂

Original PR: https://github.com/ash-jc-allen/laravel-exchange-rates/pull/136