### PR TITLE
Deprecated non-static dataprovider -> static

### DIFF
--- a/tests/Unit/Classes/ExchangeRateTest.php
+++ b/tests/Unit/Classes/ExchangeRateTest.php
@@ -44,7 +44,7 @@ final class ExchangeRateTest extends TestCase
         app(ExchangeRate::class)->driver('INVALID');
     }
 
-    public function validDriversProvider(): array
+    public static function validDriversProvider(): array
     {
         return [
             ['exchange-rates-api-io', ExchangeRatesApiIoDriver::class],


### PR DESCRIPTION
Hellooo :wave:

non-static data providers are deprecated since `PHPUnit10` and it works fine with `PHPUnit9`.

In this PR I have made the one and only data provider in the test suite `validDriversProvider` static.