### PR TITLE
Adds 'VES' as allowable currency. Already mentioned in testing.

### DIFF
--- a/src/Classes/Currency.php
+++ b/src/Classes/Currency.php
@@ -160,6 +160,7 @@ class Currency
         'UYU',
         'UZS',
         'VEF',
+        'VES',
         'VND',
         'VUV',
         'WST',

--- a/tests/Unit/Rules/ValidCurrencyTest.php
+++ b/tests/Unit/Rules/ValidCurrencyTest.php
@@ -16,6 +16,7 @@ final class ValidCurrencyTest extends TestCase
      * @testWith ["GBP"]
      *           ["BYR"]
      *           ["BYN"]
+     *           ["VES"]
      */
     public function validator_returns_true_if_the_currency_is_valid(string $currency): void
     {


### PR DESCRIPTION
Adds `VES` as an allowable currency as mentioned in issue https://github.com/ash-jc-allen/laravel-exchange-rates/issues/160
The currency is already added in test cases, so yeah, a simple addition. 