### PR TITLE
Add explicit nullable types for PHP 8.4 support

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4]
         laravel: [8.*, 9.*, 10.*, 11.*]
         include:
           - laravel: 8.*
@@ -27,6 +27,12 @@ jobs:
             php: 8.0
           - laravel: 11.*
             php: 8.1
+          - laravel: 10.*
+            php: 8.4
+          - laravel: 9.*
+            php: 8.4
+          - laravel: 8.*
+            php: 8.4
 
     name: PHP${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4]
         laravel: [8.*, 9.*, 10.*, 11.*]
         include:
           - laravel: 11.*
@@ -27,6 +27,12 @@ jobs:
             php: 8.0
           - laravel: 11.*
             php: 8.1
+          - laravel: 10.*
+            php: 8.4
+          - laravel: 9.*
+            php: 8.4
+          - laravel: 8.*
+            php: 8.4
 
     name: PHP${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**v8.0.0 (released 2024-11-14):**
+
+- Added support for PHP 8.4, updating method signature compatibility. [#162](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/162)
+
 **v7.6.0 (released 2024-09-11):**
 
 - Added "VES" as a valid currency symbol. [#161](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/161)
@@ -9,7 +13,7 @@
 
 - Added "BYN" as a valid currency symbol. [#157](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/157)
 
-**7.4.0 (released 2024-03-19):**
+**v7.4.0 (released 2024-03-19):**
 
 - Added support for `nesbot/carbon 3.0`. [#154](https://github.com/ash-jc-allen/laravel-exchange-rates/pull/154)
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,14 +2,42 @@
 
 ## Upgrading from 7.* to 8.0.0
 
-### Method Signature Change for PHP8.4 support
+### Method Signature Changes for PHP 8.4 Support
 
-Several method signatures have been changed for PHP8.4 support now that implicitly marking parameters as nullable is deprecated, the explicit nullable type must be used instead.
-The following methods have been updated to have the nullable type explicitly defined:
+With the release of PHP 8.4, implicit nullable types are deprecated. In this update, all affected method signatures have been adjusted to use explicit nullable types.
 
-- `buildCacheKey` in `AshAllenDesign\LaravelExchangeRates\Classes\CacheRepository`
+The following methods have been updated:
 
-If you are extending this class and overriding this method, you'll need to update your method signature to match the new one.
+1. `AshAllenDesign\LaravelExchangeRates\Classes\CacheRepository`:
+    - `buildCacheKey`: Changed the parameter type `Carbon $endDate` to `?Carbon $endDate`.
+
+2. `AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRateHost\ExchangeRateHostDriver`:
+    - `__construct`: Changed `RequestBuilder $requestBuilder` and `CacheRepository $cacheRepository` to `?RequestBuilder $requestBuilder` and `?CacheRepository $cacheRepository`.
+    - `exchangeRate`: Changed `Carbon $date` to `?Carbon $date`.
+    - `convert`: Changed `Carbon $date` to `?Carbon $date`.
+
+3. `AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesApiIo\ExchangeRatesApiIoDriver`:
+    - `__construct`: Changed `RequestBuilder $requestBuilder` and `CacheRepository $cacheRepository` to `?RequestBuilder $requestBuilder` and `?CacheRepository $cacheRepository`.
+    - `exchangeRate`: Changed `Carbon $date` to `?Carbon $date`.
+    - `convert`: Changed `Carbon $date` to `?Carbon $date`.
+
+4. `AshAllenDesign\LaravelExchangeRates\Drivers\ExchangeRatesDataApi\ExchangeRatesDataApiDriver`:
+    - `__construct`: Changed `RequestBuilder $requestBuilder` and `CacheRepository $cacheRepository` to `?RequestBuilder $requestBuilder` and `?CacheRepository $cacheRepository`.
+    - `exchangeRate`: Changed `Carbon $date` to `?Carbon $date`.
+    - `convert`: Changed `Carbon $date` to `?Carbon $date`.
+
+5. `AshAllenDesign\LaravelExchangeRates\Drivers\Support\SharedDriverLogicHandler`:
+    - `exchangeRate`: Changed `Carbon $date` to `?Carbon $date`.
+    - `convert`: Changed `Carbon $date` to `?Carbon $date`.
+
+6. `AshAllenDesign\LaravelExchangeRates\Facades\ExchangeRate`:
+    - `convert`: Changed `Carbon $date` to `?Carbon $date`.
+
+7. `AshAllenDesign\LaravelExchangeRates\Interfaces\ExchangeRateDriver`:
+    - `exchangeRate`: Changed `Carbon $date` to `?Carbon $date`.
+    - `convert`: Changed `Carbon $date` to `?Carbon $date`.
+
+If you are extending or implementing any of these classes and overriding the mentioned methods, you'll need to update your method signatures to match the new ones.
 
 ## Upgrading from 6.* to 7.0.0
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,16 @@
 # Upgrade Guide
 
+## Upgrading from 7.* to 8.0.0
+
+### Method Signature Change for PHP8.4 support
+
+Several method signatures have been changed for PHP8.4 support now that implicitly marking parameters as nullable is deprecated, the explicit nullable type must be used instead.
+The following methods have been updated to have the nullable type explicitly defined:
+
+- `buildCacheKey` in `AshAllenDesign\LaravelExchangeRates\Classes\CacheRepository`
+
+If you are extending this class and overriding this method, you'll need to update your method signature to match the new one.
+
 ## Upgrading from 6.* to 7.0.0
 
 ### Method Signature Change

--- a/src/Classes/CacheRepository.php
+++ b/src/Classes/CacheRepository.php
@@ -80,7 +80,7 @@ class CacheRepository
      * @param  Carbon|null  $endDate
      * @return string
      */
-    public function buildCacheKey(string $from, string|array $to, Carbon $date, Carbon $endDate = null): string
+    public function buildCacheKey(string $from, string|array $to, Carbon $date, ?Carbon $endDate = null): string
     {
         if (is_array($to)) {
             asort($to);

--- a/src/Drivers/ExchangeRateHost/ExchangeRateHostDriver.php
+++ b/src/Drivers/ExchangeRateHost/ExchangeRateHostDriver.php
@@ -19,7 +19,7 @@ class ExchangeRateHostDriver implements ExchangeRateDriver
 
     private SharedDriverLogicHandler $sharedDriverLogicHandler;
 
-    public function __construct(RequestBuilder $requestBuilder = null, CacheRepository $cacheRepository = null)
+    public function __construct(?RequestBuilder $requestBuilder = null, ?CacheRepository $cacheRepository = null)
     {
         $requestBuilder = $requestBuilder ?? new RequestBuilder();
         $this->cacheRepository = $cacheRepository ?? new CacheRepository();
@@ -55,7 +55,7 @@ class ExchangeRateHostDriver implements ExchangeRateDriver
     /**
      * @inheritDoc
      */
-    public function exchangeRate(string $from, array|string $to, Carbon $date = null): float|array
+    public function exchangeRate(string $from, array|string $to, ?Carbon $date = null): float|array
     {
         $this->sharedDriverLogicHandler->validateExchangeRateInput($from, $to, $date);
 
@@ -128,7 +128,7 @@ class ExchangeRateHostDriver implements ExchangeRateDriver
     /**
      * @inheritDoc
      */
-    public function convert(int $value, string $from, array|string $to, Carbon $date = null): float|array
+    public function convert(int $value, string $from, array|string $to, ?Carbon $date = null): float|array
     {
         return $this->sharedDriverLogicHandler->convertUsingRates(
             $this->exchangeRate($from, $to, $date),

--- a/src/Drivers/ExchangeRatesApiIo/ExchangeRatesApiIoDriver.php
+++ b/src/Drivers/ExchangeRatesApiIo/ExchangeRatesApiIoDriver.php
@@ -16,7 +16,7 @@ class ExchangeRatesApiIoDriver implements ExchangeRateDriver
 {
     private SharedDriverLogicHandler $sharedDriverLogicHandler;
 
-    public function __construct(RequestBuilder $requestBuilder = null, CacheRepository $cacheRepository = null)
+    public function __construct(?RequestBuilder $requestBuilder = null, ?CacheRepository $cacheRepository = null)
     {
         $requestBuilder = $requestBuilder ?? new RequestBuilder();
         $cacheRepository = $cacheRepository ?? new CacheRepository();
@@ -38,7 +38,7 @@ class ExchangeRatesApiIoDriver implements ExchangeRateDriver
     /**
      * @inheritDoc
      */
-    public function exchangeRate(string $from, array|string $to, Carbon $date = null): float|array
+    public function exchangeRate(string $from, array|string $to, ?Carbon $date = null): float|array
     {
         return $this->sharedDriverLogicHandler->exchangeRate($from, $to, $date);
     }
@@ -58,7 +58,7 @@ class ExchangeRatesApiIoDriver implements ExchangeRateDriver
     /**
      * @inheritDoc
      */
-    public function convert(int $value, string $from, array|string $to, Carbon $date = null): float|array
+    public function convert(int $value, string $from, array|string $to, ?Carbon $date = null): float|array
     {
         return $this->sharedDriverLogicHandler->convert($value, $from, $to, $date);
     }

--- a/src/Drivers/ExchangeRatesDataApi/ExchangeRatesDataApiDriver.php
+++ b/src/Drivers/ExchangeRatesDataApi/ExchangeRatesDataApiDriver.php
@@ -16,7 +16,7 @@ class ExchangeRatesDataApiDriver implements ExchangeRateDriver
 {
     private SharedDriverLogicHandler $sharedDriverLogicHandler;
 
-    public function __construct(RequestBuilder $requestBuilder = null, CacheRepository $cacheRepository = null)
+    public function __construct(?RequestBuilder $requestBuilder = null, ?CacheRepository $cacheRepository = null)
     {
         $requestBuilder = $requestBuilder ?? new RequestBuilder();
         $cacheRepository = $cacheRepository ?? new CacheRepository();
@@ -38,7 +38,7 @@ class ExchangeRatesDataApiDriver implements ExchangeRateDriver
     /**
      * @inheritDoc
      */
-    public function exchangeRate(string $from, array|string $to, Carbon $date = null): float|array
+    public function exchangeRate(string $from, array|string $to, ?Carbon $date = null): float|array
     {
         return $this->sharedDriverLogicHandler->exchangeRate($from, $to, $date);
     }
@@ -58,7 +58,7 @@ class ExchangeRatesDataApiDriver implements ExchangeRateDriver
     /**
      * @inheritDoc
      */
-    public function convert(int $value, string $from, array|string $to, Carbon $date = null): float|array
+    public function convert(int $value, string $from, array|string $to, ?Carbon $date = null): float|array
     {
         return $this->sharedDriverLogicHandler->convert($value, $from, $to, $date);
     }

--- a/src/Drivers/Support/SharedDriverLogicHandler.php
+++ b/src/Drivers/Support/SharedDriverLogicHandler.php
@@ -95,7 +95,7 @@ class SharedDriverLogicHandler
      * @throws RequestException
      * @throws InvalidArgumentException
      */
-    public function exchangeRate(string $from, string|array $to, Carbon $date = null): float|array
+    public function exchangeRate(string $from, string|array $to, ?Carbon $date = null): float|array
     {
         $this->validateExchangeRateInput($from, $to, $date);
 
@@ -224,7 +224,7 @@ class SharedDriverLogicHandler
      * @throws RequestException
      * @throws InvalidArgumentException
      */
-    public function convert(int $value, string $from, string|array $to, Carbon $date = null): float|array
+    public function convert(int $value, string $from, string|array $to, ?Carbon $date = null): float|array
     {
         return $this->convertUsingRates(
             $this->exchangeRate($from, $to, $date),

--- a/src/Facades/ExchangeRate.php
+++ b/src/Facades/ExchangeRate.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static array currencies(array $currencies = [])
  * @method static string|array exchangeRate(string $from, $to, ?Carbon $date = null)
  * @method static array exchangeRateBetweenDateRange(string $from, $to, Carbon $date, Carbon $endDate, array $conversions = [])
- * @method static float|array convert(int $value, string $from, $to, Carbon $date = null)
+ * @method static float|array convert(int $value, string $from, $to, ?Carbon $date = null)
  * @method static array convertBetweenDateRange(int $value, string $from, $to, Carbon $date, Carbon $endDate, array $conversions = [])
  * @method static ExchangeRateDriver shouldBustCache(bool $bustCache = true)
  * @method static ExchangeRateDriver shouldCache(bool $shouldCache = true)

--- a/src/Interfaces/ExchangeRateDriver.php
+++ b/src/Interfaces/ExchangeRateDriver.php
@@ -38,7 +38,7 @@ interface ExchangeRateDriver
      * @throws RequestException
      * @throws InvalidArgumentException
      */
-    public function exchangeRate(string $from, array|string $to, Carbon $date = null): float|array;
+    public function exchangeRate(string $from, array|string $to, ?Carbon $date = null): float|array;
 
     /**
      * Return the exchange rates between the given date range.
@@ -76,7 +76,7 @@ interface ExchangeRateDriver
      * @throws RequestException
      * @throws InvalidArgumentException
      */
-    public function convert(int $value, string $from, array|string $to, Carbon $date = null): float|array;
+    public function convert(int $value, string $from, array|string $to, ?Carbon $date = null): float|array;
 
     /**
      * Return an array of the converted values between the given date range.


### PR DESCRIPTION
This update adds explicit nullable types to method signatures to ensure compatibility with PHP 8.4, as implicit nullability is deprecated.

Updated method signatures across multiple classes to use explicit nullable types (?Type).
Modified the buildCacheKey method in CacheRepository and related methods in drivers and interfaces.
Started work on the upgrade guide and changelog for PHP 8.4 compatibility.
Updated workflows to align with the new PHP version requirements.